### PR TITLE
Made Docker (for integration tests) uses Chromium + ChromiumDriver

### DIFF
--- a/py.Dockerfile
+++ b/py.Dockerfile
@@ -5,17 +5,8 @@ FROM python:$PYTHON_VERSION
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-RUN apt-get -y update 
-RUN apt-get install -y wget unzip
-
-# Install Google Chrome
-RUN wget -q 'https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_107.0.5304.68-1_amd64.deb' -O google-chrome.deb
-RUN apt-get install -y ./google-chrome.deb
-
-# Install Chromedriver
-RUN wget -q 'https://chromedriver.storage.googleapis.com/107.0.5304.62/chromedriver_linux64.zip'
-RUN unzip chromedriver_linux64.zip
-ENV PATH="$PATH:$PWD"
+RUN apt-get -y update
+RUN apt-get install -y chromium chromium-driver
 
 COPY . /usr/local/miniwob-plusplus/
 WORKDIR /usr/local/miniwob-plusplus/


### PR DESCRIPTION
# Description

Made the Docker image (for integration tests) uses Chromium + ChromiumDriver (both installed from apt-get) instead of Google Chrome (deb download) + ChromeDriver (zip file download). This slightly simplifies the docker image.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
