### PR TITLE
Edited the space descriptions in the documentation

### DIFF
--- a/docs/content/python_usage.md
+++ b/docs/content/python_usage.md
@@ -61,9 +61,225 @@ Common arguments include:
 (observation_space)=
 ## Observation Space
 
-TODO: Add details
+### Observation Object
+
+In all MiniWoB++ environments, an observation is a `dict` with the following fields:
+
+```{list-table}
+:header-rows: 1
+* - Key
+  - Type
+  - Description
+* - `utterance`
+  - `str`
+  - Task instruction string.
+* - `field_keys`
+  - `tuple[str]`
+  - Environment-specific task field keys. (**TODO**: Implement this in code)
+* - `field_values`
+  - `tuple[str]`
+  - Task field values extracted from the task instruction. (**TODO**: Implement this in code)
+* - `screenshot`
+  - `np.ndarray` with shape `(height, width, 3)` and type `uint8`
+  - Screenshot as RGB values for each pixel. Note that some elements such as
+    opened dropdown may not be captured in the screenshot.
+* - `dom_elements`
+  - `list[dict]`
+  - List of feature dicts, each describing a DOM elements (see below).
+```
+
+### DOM Element Features
+
+Each feature dict in `dom_elements` has the following fields:
+
+```{list-table}
+:header-rows: 1
+* - Key
+  - Type
+  - Description
+* - `ref`
+  - `int`
+  - Non-zero integer ID.
+    * The `ref` for normal HTML elements start from 1.
+    * Each HTML element retains the same `ref` during the same episode.
+    * Non-empty text nodes are converted into pseudo-elements with `ref` counting down from -1.[^1]
+* - `parent`
+  - `int`
+  - `ref` of the parent. For the root DOM element, `parent` will be 0.
+* - `left`
+  - `np.ndarray` with shape `(1,)` and type `float32`
+  - Left coordinate relative to the screen (can be negative).
+* - `top`
+  - `np.ndarray` with shape `(1,)` and type `float32`
+  - Top coordinate relative to the screen (can be negative).
+* - `width`
+  - `np.ndarray` with shape `(1,)` and type `float32`
+  - Element width.
+* - `height`
+  - `np.ndarray` with shape `(1,)` and type `float32`
+  - Element height.
+* - `tag`
+  - `str`
+  - HTML tag.
+    * For normal elements, this is the uppercased tag name (e.g., `"DIV"`).
+    * For `<input>` elements, the input type is appended (e.g., `"INPUT_text"`).
+    * Non-empty text nodes become pseudo-elements with tag `"t"`.[^1]
+* - `text`
+  - `str`
+  - Text content, which is non-empty only for leaf elements.[^1]
+* - `value`
+  - `str`
+  - Value of `<input>` element.
+* - `id`
+  - `str`
+  - HTML `id` attribute.
+* - `classes`
+  - `str`
+  - HTML `class` attribute (multiple classes are separated by spaces).
+* - `bg_color`
+  - `np.ndarray` with shape `(4,)` and type `float32`
+  - Background color as RGBA value.
+* - `fg_color`
+  - `np.ndarray` with shape `(4,)` and type `float32`
+  - Foreground color as RGBA value.
+* - `flags`
+  - `np.ndarray` with shape `(4,)` and type `int8`
+  - Binary flags:
+    * (`focused`) Whether the element is being focused on.
+    * (`tampered`) Whether the element has been tampered (clicked, focused, typed, etc.).
+    * (`targeted`) Whether the element is an event target (for recorded demonstrations).
+    * (`is_leaf`) Whether the element is a leaf.
+```
+
+[^1]: **Note:** Regarding text nodes:
+    * For an element with a single text node as its child (e.g., `<button>Submit</button>`),
+      a text pseudo-element will not be created. The element will become a leaf with the
+      `text` feature filled in.
+    * For an element with a text node as one of its children (e.g., `<button>Submit <b>NOW</b></button>`),
+      a text pseudo-element (negative `ref` and `tag = "t"`) will be created for the text node.
 
 (action_space)=
 ## Action Space
 
-TODO: Add details
+### Supported Actions
+
+MiniWoB++ environments support the following actions.
+
+```{list-table}
+:header-rows: 1
+* - Name
+  - Description
+* - `NONE`
+  - Do nothing for the current step.
+* - `CLICK_COORDS`
+  - Click on the specified coordinates.
+* - `DBLCLICK_COORDS`
+  - Double-click on the specified coordinates.
+* - `MOUSEDOWN_COORDS`
+  - Start dragging on the specified coordinates.
+* - `MOUSEUP_COORDS`
+  - Stop dragging on the specified coordinates.
+* - `CLICK_ELEMENT`
+  - Click on the specified element.
+* - `DBLCLICK_ELEMENT`
+  - Double-click on the specified element.
+* - `MOUSEDOWN_ELEMENT`
+  - Start dragging on the specified element.
+* - `MOUSEUP_ELEMENT`
+  - Stop dragging on the specified element.
+* - `SCROLL_UP`
+  - Scroll up on the mouse wheel.
+* - `SCROLL_DOWN`
+  - Scroll down on the mouse wheel.
+* - `PRESS_KEY`
+  - Press the specified key or key combination.
+* - `TYPE_TEXT`
+  - Type the specified string.
+* - `TYPE_FIELD`
+  - Type the value of the specified task field.
+* - `FOCUS_ELEMENT_AND_TYPE_TEXT`
+  - Click on the specified element, and then type the specified string.
+* - `FOCUS_ELEMENT_AND_TYPE_FIELD`
+  - Click on the specified element, and then type the value of the specified task field.
+```
+
+### Action Configs
+
+The list of selected actions, along with other configurations, can be customized
+by passing a `miniwob.action.ActionSpaceConfig` object to the `action_space_config` argument
+during environment construction.
+The `ActionSpaceConfig` object has the following fields:
+
+```{list-table}
+:header-rows: 1
+* - Key
+  - Type
+  - Description
+* - `action_types`
+  - `Sequence[ActionTypes]` or `Sequence[str]`
+  - An ordered sequence of action types to include.
+* - `screen_width`
+  - `float`
+  - Screen width. Will be overridden by the environment constructor.
+* - `screen_height`
+  - `float`
+  - Screen height. Will be overridden by the environment constructor.
+* - `coord_bins`
+  - `tuple[int, int]`
+  - If specified, bin the x and y coordinates to these numbers of bins.
+    Mouse actions will be executed at the middle of the specified partition.
+* - `allowed_keys`
+  - `Sequence[str]`
+  - An ordered sequence of allowed keys and key combinations for the `PRESS_KEY` action.
+* - `text_max_len`
+  - `int`
+  - Maximum text length for the `TYPE_TEXT` action.
+* - `text_charset`
+  - `str` or `set[str]`
+  - Character set for the `TYPE_TEXT` action.
+```
+
+### Action Object
+
+An action is a `dict` whose field inclusion depends on the selected actions:
+
+```{list-table}
+:header-rows: `
+* - Key
+  - Type
+  - Description
+* - `action_type`
+  - `int`
+  - Action type index from the `action_types` list in the config.
+* - `coords`
+  - `np.ndarray` of shape `(2,)`
+  - Coordinates. Included when any `*COORDS` action is selected.
+    Depending on the `coord_bins` config, `coords` can be of type `int8` (binned) or `float32` (unbinned).
+* - `ref`
+  - `int`
+  - Element `ref` ID. Included when any `*_ELEMENT*` action is selected.
+    If no element has the specified `ref`, the action becomes a no-op.
+* - `key`
+  - `int`
+  - Key index from the `allowed_keys` list in the config.
+    Included when the `PRESS_KEY` action is selected.
+* - `text`
+  - `str`
+  - Text to type. Included when any `*_TYPE_TEXT` action is selected.
+* - `field`
+  - `int`
+  - Task field index. Included when any `*_TYPE_FIELD` action is selected.
+```
+
+### Presets
+
+The following preset names can be specified in place of the `ActionSpaceConfig` object:
+(**TODO**: Implement this in code)
+
+* `all_supported`: Select all supported actions, including redundant ones.
+* `shi17`: The action space from (Shi et al., 2017)
+  [World of Bits: An Open-Domain Platform for Web-Based Agents](http://proceedings.mlr.press/v70/shi17a/shi17a.pdf).
+* `liu18`: The action space from (Liu et al., 2018)
+  [Reinforcement Learning on Web Interfaces Using Workflow-Guided Exploration](https://arxiv.org/abs/1802.08802).
+* `humphreys22`: The action space from (Humphreys et al., 2022)
+  [A data-driven approach for learning to control computers](https://arxiv.org/abs/2202.08137).

--- a/miniwob/observation.py
+++ b/miniwob/observation.py
@@ -32,19 +32,15 @@ def get_observation_space(screen_width: int, screen_height: int) -> spaces.Space
             "ref": spaces.Discrete(MAX_REF - MIN_REF, start=MIN_REF),
             # `ref` ID of the parent (0 = no parent, for root element).
             "parent": spaces.Discrete(MAX_REF),
-            # Position (left, top)
-            "pos": spaces.Box(
-                np.array([float("-inf"), float("-inf")]),
-                np.array([float("inf"), float("inf")]),
-            ),
-            # Size (width, height)
-            "size": spaces.Box(
-                np.array([0.0, 0.0]), np.array([float("inf"), float("inf")])
-            ),
+            # Position and size
+            "left": spaces.Box(float("-inf"), float("inf")),
+            "top": spaces.Box(float("-inf"), float("inf")),
+            "width": spaces.Box(0.0, float("inf")),
+            "height": spaces.Box(0.0, float("inf")),
             # Tag:
             # For normal elements, this is the uppercased tag name (e.g., "DIV").
             # For <input> elements, the input type is appended (e.g., "INPUT_text").
-            # Each non-empty text node becomes a pseudo-elements with tag "t".
+            # Non-empty text nodes become pseudo-elements with tag "t".
             "tag": spaces.Text(max_length=ATTRIBUTE_MAX_LENGTH, charset=ASCII_CHARSET),
             # Text content of leaf nodes.
             "text": spaces.Text(
@@ -100,8 +96,10 @@ def serialize_dom_element(element: DOMElement) -> Dict[str, Any]:
     serialized = {
         "ref": element.ref,
         "parent": element.parent.ref if element.parent else 0,
-        "pos": np.array([element.left, element.top], dtype=np.float32),
-        "size": np.array([element.width, element.height], dtype=np.float32),
+        "left": np.array([element.left], dtype=np.float32),
+        "top": np.array([element.top], dtype=np.float32),
+        "width": np.array([element.width], dtype=np.float32),
+        "height": np.array([element.height], dtype=np.float32),
         "tag": element.tag[:ATTRIBUTE_MAX_LENGTH],
         "text": (element.text or "")[:TEXT_MAX_LENGTH],
         "value": str(element.value or "")[:TEXT_MAX_LENGTH],

--- a/tests/test_action.py
+++ b/tests/test_action.py
@@ -84,8 +84,8 @@ class RepeatedTester:
 
     def create_click_element_center_action(self, env, element):
         """Create an action that clicks the element's center."""
-        left, top = element["pos"].tolist()
-        width, height = element["size"].tolist()
+        left, top = element["left"].item(), element["top"].item()
+        width, height = element["width"].item(), element["height"].item()
         return self.create_click_coords_action(
             env, left + (width / 2), top + (height / 2)
         )


### PR DESCRIPTION
# Description

- Edited descriptions of the action and observation spaces in the documentation. Left a few TODOs for features that are not implemented yet.
- In the observation space, changed the "pos" and "size" features to the more explicit "left", "top", "width", and "height". This prevents index ordering confusion (CSS uses left-top; Python array uses top-left).

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
