### PR TITLE
Added -e to pip install commands.

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -21,7 +21,7 @@ jobs:
         run: pip install -r docs/requirements.txt
 
       - name: Install MiniWoB++
-        run: pip install .
+        run: pip install -e .
 
       - name: Build Envs Docs
         run: python docs/_scripts/gen_mds.py

--- a/py.Dockerfile
+++ b/py.Dockerfile
@@ -10,4 +10,4 @@ RUN apt-get install -y chromium chromium-driver
 
 COPY . /usr/local/miniwob-plusplus/
 WORKDIR /usr/local/miniwob-plusplus/
-RUN pip install .[testing] --no-cache-dir
+RUN pip install -e .[testing] --no-cache-dir


### PR DESCRIPTION
# Description

Changed `pip install .` to `pip install -e .`.

Without `-e`, the CI tests didn't trigger an error since `miniwob/` is also in the working directory, but doc generation silently failed with message `No module named 'miniwob.envs'`.

Tested in a local branch in my fork (https://ppasupat.github.io/miniwob-plusplus/environments/list/).

Fixes #38 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
