### PR TITLE
Handle Unicode texts

### DIFF
--- a/docs/_scripts/gen_env_list.py
+++ b/docs/_scripts/gen_env_list.py
@@ -142,6 +142,7 @@ Some are harder versions of the existing tasks, while some are completely new.""
             "email-inbox-noscroll",
             "email-inbox-reply",
             "email-inbox-star-reply",
+            "unicode-test",
         ],
     },
     {
@@ -267,6 +268,7 @@ ENVS_DESCRIPTIONS = {
     "chase-circle": "Keep your mouse inside a moving circle.",
     "moving-items": "Click moving items before they disappear.",
     "simon-says": "Push the buttons in the order shown.",
+    "unicode-test": "Click on the button with the correct Unicode text.",
 }
 
 file_start_content = """# Environments List

--- a/miniwob/action.py
+++ b/miniwob/action.py
@@ -1,7 +1,7 @@
 """MiniWoB action space."""
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Dict, Optional, Sequence, Set, Tuple, Union
+from typing import Any, Dict, Optional, Sequence, Tuple
 
 import numpy as np
 from gymnasium import spaces
@@ -9,7 +9,6 @@ from selenium.webdriver import Chrome as ChromeDriver
 
 from miniwob import selenium_actions
 from miniwob.constants import (
-    ASCII_CHARSET,
     DEFAULT_ALLOWED_KEYS,
     DEFAULT_SCROLL_AMOUNT,
     DEFAULT_SCROLL_TIME,
@@ -17,6 +16,7 @@ from miniwob.constants import (
     MAX_REF,
     TYPING_MAX_LENGTH,
 )
+from miniwob.spaces import Unicode
 
 
 Action = Dict[str, Any]
@@ -92,7 +92,6 @@ class ActionSpaceConfig:
             for the PRESS_KEY action. The order will be used for interpreting
             the Discrete space.
         text_max_len: Maximum text length for the TYPE_TEXT action.
-        text_charset: Character set for the TYPE_TEXT action.
     """
 
     action_types: Sequence[ActionTypes]
@@ -103,7 +102,6 @@ class ActionSpaceConfig:
     scroll_time: int = DEFAULT_SCROLL_TIME
     allowed_keys: Sequence[str] = DEFAULT_ALLOWED_KEYS
     text_max_len: int = TYPING_MAX_LENGTH
-    text_charset: Union[str, Set[str]] = ASCII_CHARSET
 
     @classmethod
     def get_preset(cls, name="all_supported"):
@@ -198,7 +196,7 @@ class ActionSpaceConfig:
         if ActionTypes.PRESS_KEY in self.action_types:
             space["key"] = spaces.Discrete(len(self.allowed_keys))
         if TEXT_ACTIONS.intersection(self.action_types):
-            space["text"] = spaces.Text(self.text_max_len, charset=self.text_charset)
+            space["text"] = Unicode(self.text_max_len)
         if FIELD_ACTIONS.intersection(self.action_types):
             space["field"] = spaces.Discrete(MAX_FIELDS)
         return spaces.Dict(space)

--- a/miniwob/envs/miniwob_envs.py
+++ b/miniwob/envs/miniwob_envs.py
@@ -2118,6 +2118,28 @@ class TicTacToeEnv(MiniWoBEnvironment):
     subdomain = "tic-tac-toe"
 
 
+class UnicodeTestEnv(MiniWoBEnvironment):
+    """
+    ## Description
+
+    Click on the button with the correct Unicode text.
+
+    ## Example utterances
+
+    * Click on the "Cancél" button.
+    * Click on the "ÖK" button.
+    * Click on the "ヘルプ" button.
+    * Click on the "取消" button.
+    * Click on the "确定" button.
+
+    ## Utterance fields
+
+    * target
+    """
+
+    subdomain = "unicode-test"
+
+
 class UseAutocompleteEnv(MiniWoBEnvironment):
     """
     ## Description

--- a/miniwob/html/flight/Alaska-auto-medium/index.html
+++ b/miniwob/html/flight/Alaska-auto-medium/index.html
@@ -149,7 +149,7 @@
 	<li id="contact-link"><a href="/contact">Contact us</a></li>
 </ul>
     <div id="more-links"></div>  
-<div id="copyright">(c) 2017 Alaska Airlines, Inc.</div>
+<div id="copyright">&copy; 2017 Alaska Airlines, Inc.</div>
 <div id="debug">v3-28-6227-21813  </div>
 </div>
 <script type="text/javascript" src="scripts/main.js"></script>

--- a/miniwob/html/flight/Alaska-auto/index.html
+++ b/miniwob/html/flight/Alaska-auto/index.html
@@ -149,7 +149,7 @@
 	<li id="contact-link"><a href="/contact">Contact us</a></li>
 </ul>
     <div id="more-links"></div>  
-<div id="copyright">(c) 2017 Alaska Airlines, Inc.</div>
+<div id="copyright">&copy; 2017 Alaska Airlines, Inc.</div>
 <div id="debug">v3-28-6227-21813  </div>
 </div>
 <script type="text/javascript" src="scripts/main.js"></script>

--- a/miniwob/html/flight/Alaska/index.html
+++ b/miniwob/html/flight/Alaska/index.html
@@ -149,7 +149,7 @@
 	<li id="contact-link"><a href="/contact">Contact us</a></li>
 </ul>
     <div id="more-links"></div>  
-<div id="copyright">(c) 2017 Alaska Airlines, Inc.</div>
+<div id="copyright">&copy; 2017 Alaska Airlines, Inc.</div>
 <div id="debug">v3-28-6227-21813  </div>
 </div>
 <script type="text/javascript" src="scripts/main.js"></script>

--- a/miniwob/html/miniwob/terminal.html
+++ b/miniwob/html/miniwob/terminal.html
@@ -34,7 +34,7 @@ var TERMINAL_TEMPLATE =
     <div class="terminal-line">
       <span class="user">user$</span>
       <span id="active-input" class="command"></span>
-      <span id="input-flicker">_</span>
+      <span id="input-flicker">&block;</span>
     </div>
   </div>
 </div>

--- a/miniwob/observation.py
+++ b/miniwob/observation.py
@@ -5,7 +5,6 @@ import numpy as np
 from gymnasium import spaces
 
 from miniwob.constants import (
-    ASCII_CHARSET,
     ATTRIBUTE_MAX_LENGTH,
     FIELD_KEY_MAX_LENGTH,
     FIELD_VALUE_MAX_LENGTH,
@@ -15,6 +14,7 @@ from miniwob.constants import (
     UTTERANCE_MAX_LENGTH,
 )
 from miniwob.dom import DOMElement
+from miniwob.spaces import Unicode
 
 
 Observation = Dict[str, Any]
@@ -22,10 +22,9 @@ Observation = Dict[str, Any]
 
 def get_observation_space(screen_width: int, screen_height: int) -> spaces.Space:
     """Return the space of observations."""
-    utterance_space = spaces.Text(
+    utterance_space = Unicode(
         min_length=0,
         max_length=UTTERANCE_MAX_LENGTH,
-        charset=ASCII_CHARSET,
     )
     element_space = spaces.Dict(
         {
@@ -44,22 +43,26 @@ def get_observation_space(screen_width: int, screen_height: int) -> spaces.Space
             # For normal elements, this is the uppercased tag name (e.g., "DIV").
             # For <input> elements, the input type is appended (e.g., "INPUT_text").
             # Non-empty text nodes become pseudo-elements with tag "t".
-            "tag": spaces.Text(max_length=ATTRIBUTE_MAX_LENGTH, charset=ASCII_CHARSET),
+            "tag": Unicode(max_length=ATTRIBUTE_MAX_LENGTH),
             # Text content of leaf nodes.
-            "text": spaces.Text(
-                min_length=0, max_length=TEXT_MAX_LENGTH, charset=ASCII_CHARSET
+            "text": Unicode(
+                min_length=0,
+                max_length=TEXT_MAX_LENGTH,
             ),
             # Value of <input> elements.
-            "value": spaces.Text(
-                min_length=0, max_length=TEXT_MAX_LENGTH, charset=ASCII_CHARSET
+            "value": Unicode(
+                min_length=0,
+                max_length=TEXT_MAX_LENGTH,
             ),
             # HTML id attribute
-            "id": spaces.Text(
-                min_length=0, max_length=ATTRIBUTE_MAX_LENGTH, charset=ASCII_CHARSET
+            "id": Unicode(
+                min_length=0,
+                max_length=ATTRIBUTE_MAX_LENGTH,
             ),
             # HTML class attribute (multiple classes are separated by spaces)
-            "classes": spaces.Text(
-                min_length=0, max_length=ATTRIBUTE_MAX_LENGTH, charset=ASCII_CHARSET
+            "classes": Unicode(
+                min_length=0,
+                max_length=ATTRIBUTE_MAX_LENGTH,
             ),
             # Colors (RGBA)
             "bg_color": spaces.Box(
@@ -87,13 +90,13 @@ def get_observation_space(screen_width: int, screen_height: int) -> spaces.Space
     fields_space = spaces.Sequence(
         spaces.Tuple(
             (
-                spaces.Text(
-                    min_length=0, max_length=FIELD_KEY_MAX_LENGTH, charset=ASCII_CHARSET
+                Unicode(
+                    min_length=0,
+                    max_length=FIELD_KEY_MAX_LENGTH,
                 ),
-                spaces.Text(
+                Unicode(
                     min_length=0,
                     max_length=FIELD_VALUE_MAX_LENGTH,
-                    charset=ASCII_CHARSET,
                 ),
             )
         )

--- a/miniwob/registration.py
+++ b/miniwob/registration.py
@@ -400,6 +400,10 @@ def register_miniwob_envs():
         entry_point="miniwob.envs.miniwob_envs:TicTacToeEnv",
     )
     register(
+        id="miniwob/unicode-test-v1",
+        entry_point="miniwob.envs.miniwob_envs:UnicodeTestEnv",
+    )
+    register(
         id="miniwob/use-autocomplete-v1",
         entry_point="miniwob.envs.miniwob_envs:UseAutocompleteEnv",
     )

--- a/miniwob/scripts/gen_env_classes.py
+++ b/miniwob/scripts/gen_env_classes.py
@@ -111,7 +111,7 @@ def main():
     # Get the list of all miniwob environments.
     envs = []
     for env_id, env_spec in gymnasium.registry.items():
-        if env_spec.namespace == "miniwob" and "flight." in env_id:
+        if env_spec.namespace == "miniwob":
             envs.append(env_id)
     envs.sort(key=lambda env_id: _raw_env_name(env_id))
 

--- a/miniwob/spaces.py
+++ b/miniwob/spaces.py
@@ -40,6 +40,19 @@ class Unicode(Space[str]):
             sample_charset: Character set for sampling from the space.
             seed: The seed for sampling from the space.
         """
+        assert np.issubdtype(
+            type(min_length), np.integer
+        ), f"Expects the min_length to be an integer, actual type: {type(min_length)}"
+        assert np.issubdtype(
+            type(max_length), np.integer
+        ), f"Expects the max_length to be an integer, actual type: {type(max_length)}"
+        assert (
+            0 <= min_length
+        ), f"Minimum text length must be non-negative, actual value: {min_length}"
+        assert (
+            min_length <= max_length
+        ), f"The min_length must be less than or equal to the max_length, min_length: {min_length}, max_length: {max_length}"
+
         self.min_length: int = int(min_length)
         self.max_length: int = int(max_length)
         self._sample_charlist: tuple[str, ...] = tuple(sample_charset)
@@ -47,9 +60,20 @@ class Unicode(Space[str]):
 
     def sample(
         self,
-        mask: None | Any = None,
+        mask: None | (tuple[int | None, NDArray[np.int8] | None]) = None,
     ):
-        """Generates a single random sample from this space."""
+        """Generates a single random sample from this space.
+
+        Args:
+            mask: An optional tuples of length and mask for the text.
+                The length is expected to be between the `min_length` and `max_length`.
+                Otherwise, a random integer between `min_length` and `max_length` is selected.
+                The mask is expected to be a numpy array of length of the charset passed with `dtype == np.int8`.
+                If the charlist mask is all zero then an empty string is returned no matter the `min_length`
+
+        Returns:
+            A sampled string from the space
+        """
         if mask is not None:
             assert isinstance(
                 mask, tuple

--- a/miniwob/spaces.py
+++ b/miniwob/spaces.py
@@ -1,7 +1,5 @@
 """Custom spaces for MiniWoB++."""
-from __future__ import annotations
-
-from typing import Any
+from typing import Any, FrozenSet, Optional, Tuple, Union
 
 import numpy as np
 from gymnasium.spaces import Box
@@ -29,8 +27,8 @@ class Unicode(Space[str]):
         max_length: int,
         *,
         min_length: int = 1,
-        sample_charset: frozenset[str] | str = alphanumeric,
-        seed: int | np.random.Generator | None = None,
+        sample_charset: Union[FrozenSet[str], str] = alphanumeric,
+        seed: Union[int, np.random.Generator, None] = None,
     ):
         """Constructor for the `Unicode` space.
 
@@ -55,12 +53,12 @@ class Unicode(Space[str]):
 
         self.min_length: int = int(min_length)
         self.max_length: int = int(max_length)
-        self._sample_charlist: tuple[str, ...] = tuple(sample_charset)
+        self._sample_charlist: Tuple[str, ...] = tuple(sample_charset)
         super().__init__(dtype=str, seed=seed)
 
     def sample(
         self,
-        mask: None | (tuple[int | None, NDArray[np.int8] | None]) = None,
+        mask: Optional[Tuple[Optional[int], Optional[NDArray[np.int8]]]] = None,
     ):
         """Generates a single random sample from this space.
 

--- a/miniwob/spaces.py
+++ b/miniwob/spaces.py
@@ -1,0 +1,154 @@
+"""Custom spaces for MiniWoB++."""
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+from gymnasium.spaces import Box
+from gymnasium.spaces.space import Space
+from gymnasium.spaces.text import alphanumeric
+from gymnasium.spaces.utils import flatdim, flatten, flatten_space, unflatten
+from numpy.typing import NDArray
+
+
+MAX_UNICODE_CODEPOINT = 0x10FFFF
+
+
+class Unicode(Space[str]):
+    """A space representing a unicode string.
+
+    Unicode is a replacement for the Text space in Gymnasium, with the
+    following differences:
+
+    - Each character can be an arbitrary unicode character.
+    - The sample method samples from the specified character set.
+    """
+
+    def __init__(
+        self,
+        max_length: int,
+        *,
+        min_length: int = 1,
+        sample_charset: frozenset[str] | str = alphanumeric,
+        seed: int | np.random.Generator | None = None,
+    ):
+        """Constructor for the `Unicode` space.
+
+        Args:
+            max_length: Maximum text length (in characters).
+            min_length: Minimum text length (in characters). Defaults to 1.
+            sample_charset: Character set for sampling from the space.
+            seed: The seed for sampling from the space.
+        """
+        self.min_length: int = int(min_length)
+        self.max_length: int = int(max_length)
+        self._sample_charlist: tuple[str, ...] = tuple(sample_charset)
+        super().__init__(dtype=str, seed=seed)
+
+    def sample(
+        self,
+        mask: None | Any = None,
+    ):
+        """Generates a single random sample from this space."""
+        if mask is not None:
+            assert isinstance(
+                mask, tuple
+            ), f"Expects the mask type to be a tuple, actual type: {type(mask)}"
+            assert (
+                len(mask) == 2
+            ), f"Expects the mask length to be two, actual length: {len(mask)}"
+            length, charlist_mask = mask
+
+            if length is not None:
+                assert np.issubdtype(
+                    type(length), np.integer
+                ), f"Expects the Text sample length to be an integer, actual type: {type(length)}"
+                assert (
+                    self.min_length <= length <= self.max_length
+                ), f"Expects the Text sample length be between {self.min_length} and {self.max_length}, actual length: {length}"
+
+            if charlist_mask is not None:
+                assert isinstance(
+                    charlist_mask, np.ndarray
+                ), f"Expects the Text sample mask to be an np.ndarray, actual type: {type(charlist_mask)}"
+                assert (
+                    charlist_mask.dtype == np.int8
+                ), f"Expects the Text sample mask to be an np.ndarray, actual dtype: {charlist_mask.dtype}"
+                assert charlist_mask.shape == (
+                    len(self._sample_charlist),
+                ), f"expects the Text sample mask to be {(len(self._sample_charlist),)}, actual shape: {charlist_mask.shape}"
+                assert np.all(
+                    np.logical_or(charlist_mask == 0, charlist_mask == 1)
+                ), f"Expects all masks values to 0 or 1, actual values: {charlist_mask}"
+        else:
+            length, charlist_mask = None, None
+
+        if length is None:
+            length = self.np_random.integers(self.min_length, self.max_length + 1)
+
+        if charlist_mask is None:
+            string = self.np_random.choice(self._sample_charlist, size=length)
+        else:
+            valid_mask = charlist_mask == 1
+            valid_indexes = np.where(valid_mask)[0]
+            if len(valid_indexes) == 0:
+                if self.min_length == 0:
+                    string = ""
+                else:
+                    # Otherwise the string will not be contained in the space
+                    raise ValueError(
+                        f"Trying to sample with a minimum length > 0 ({self.min_length}) but the character mask is all zero meaning that no character could be sampled."
+                    )
+            else:
+                string = "".join(
+                    self._sample_charlist[index]
+                    for index in self.np_random.choice(valid_indexes, size=length)
+                )
+
+        return "".join(string)
+
+    def contains(self, x: Any) -> bool:
+        """Return boolean specifying if x is a valid member of this space."""
+        return isinstance(x, str) and self.min_length <= len(x) <= self.max_length
+
+    def __repr__(self) -> str:
+        """Gives a string representation of this space."""
+        return f"Unicode({self.min_length}, {self.max_length})"
+
+    def __eq__(self, other: Any) -> bool:
+        """Check whether ``other`` is equivalent to this instance."""
+        return (
+            isinstance(other, Unicode)
+            and self.min_length == other.min_length
+            and self.max_length == other.max_length
+        )
+
+    @property
+    def is_np_flattenable(self) -> bool:
+        """The flattened version is the array of unicode codepoints, padded with 0 to the max character length."""
+        return True
+
+
+@flatdim.register(Unicode)
+def _flatdim_unicode(space: Unicode) -> int:
+    return space.max_length
+
+
+@flatten.register(Unicode)
+def _flatten_unicode(space: Unicode, x: str) -> NDArray[np.int32]:
+    arr = np.full(shape=(space.max_length,), fill_value=0, dtype=np.int32)
+    for i, val in enumerate(x):
+        arr[i] = ord(val)
+    return arr
+
+
+@unflatten.register(Unicode)
+def _unflatten_unicode(space: Unicode, x: NDArray[np.int32]) -> str:
+    return "".join(chr(val) for val in x if val)
+
+
+@flatten_space.register(Unicode)
+def _flatten_space_unicode(space: Unicode) -> Box:
+    return Box(
+        low=0, high=MAX_UNICODE_CODEPOINT, shape=(space.max_length,), dtype=np.int32
+    )

--- a/tests/test_action.py
+++ b/tests/test_action.py
@@ -645,8 +645,8 @@ class TestScrollText2(RepeatedTester):
             }[target]
             for element in obs["dom_elements"]:
                 if element["tag"] == "textarea":
-                    left = int(element["left"]) + 5
-                    top = int(element["top"]) + 5
+                    left = int(element["left"].item()) + 5
+                    top = int(element["top"].item()) + 5
                     return self.create_coords_action(env, left, top, action_type)
             assert False, "Textarea not found"
         else:
@@ -665,8 +665,8 @@ class TestScrollText2WithPressKey(RepeatedTester):
             # Click on the textarea.
             for element in obs["dom_elements"]:
                 if element["tag"] == "textarea":
-                    left = int(element["left"]) + 5
-                    top = int(element["top"]) + 5
+                    left = int(element["left"].item()) + 5
+                    top = int(element["top"].item()) + 5
                     return self.create_click_coords_action(env, left, top)
             assert False, "Textarea not found"
         elif step < self.MAX_STEPS - 1:

--- a/tests/test_spaces.py
+++ b/tests/test_spaces.py
@@ -1,0 +1,38 @@
+"""Test the custom spaces."""
+import numpy as np
+from gymnasium.spaces import Box
+from gymnasium.spaces.utils import flatdim, flatten, flatten_space, unflatten
+
+from miniwob.spaces import Unicode
+
+
+class TestUnicode:
+    """Test the Unicode space."""
+
+    def test_unicode_contains(self):
+        """Test the `contains` method."""
+        space = Unicode(20, min_length=4, sample_charset=frozenset("abc"))
+        assert space.contains("Hello, World!")
+        assert space.contains("Привет мир!")
+        assert space.contains("This has 20 letters.")
+        assert not space.contains("This is longer than 20 letters.")
+        assert not space.contains("cab")
+
+    def test_unicode_sample(self):
+        """Test the `sample` method."""
+        space = Unicode(20, min_length=4, sample_charset=frozenset("abc"))
+        for _ in range(5):
+            x = space.sample()
+            assert all(char in "abc" for char in x)
+            assert 4 <= len(x) <= 20
+
+    def test_unicode_flatten(self):
+        """Test the flatten utilities for Unicode."""
+        space = Unicode(10, min_length=4, sample_charset=frozenset("abc"))
+        assert flatdim(space) == 10
+        flattened_space = flatten_space(space)
+        assert isinstance(flattened_space, Box)
+        x = "你好世界"
+        flattened_x = flatten(space, x)
+        assert np.all(flattened_x == np.array([20320, 22909, 19990, 30028] + [0] * 6))
+        assert x == unflatten(space, flattened_x)

--- a/tests/test_spaces.py
+++ b/tests/test_spaces.py
@@ -11,7 +11,7 @@ class TestUnicode:
 
     def test_unicode_contains(self):
         """Test the `contains` method."""
-        space = Unicode(20, min_length=4, sample_charset=frozenset("abc"))
+        space = Unicode(20, min_length=4, charset="abc")
         assert space.contains("Hello, World!")
         assert space.contains("Привет мир!")
         assert space.contains("This has 20 letters.")
@@ -20,7 +20,7 @@ class TestUnicode:
 
     def test_unicode_sample(self):
         """Test the `sample` method."""
-        space = Unicode(20, min_length=4, sample_charset=frozenset("abc"))
+        space = Unicode(20, min_length=4, charset="abc")
         for _ in range(5):
             x = space.sample()
             assert all(char in "abc" for char in x)
@@ -28,7 +28,7 @@ class TestUnicode:
 
     def test_unicode_flatten(self):
         """Test the flatten utilities for Unicode."""
-        space = Unicode(10, min_length=4, sample_charset=frozenset("abc"))
+        space = Unicode(10, min_length=4, charset="abc")
         assert flatdim(space) == 10
         flattened_space = flatten_space(space)
         assert isinstance(flattened_space, Box)

--- a/tests/test_spaces.py
+++ b/tests/test_spaces.py
@@ -1,6 +1,6 @@
 """Test the custom spaces."""
 import numpy as np
-from gymnasium.spaces import Box
+from gymnasium.spaces import Box, Text
 from gymnasium.spaces.utils import flatdim, flatten, flatten_space, unflatten
 
 from miniwob.spaces import Unicode
@@ -35,4 +35,16 @@ class TestUnicode:
         x = "你好世界"
         flattened_x = flatten(space, x)
         assert np.all(flattened_x == np.array([20320, 22909, 19990, 30028] + [0] * 6))
+        assert x == unflatten(space, flattened_x)
+
+    def test_text_flatten(self):
+        """Test that the space utilities still work with Text."""
+        space = Text(10, min_length=4, charset="abc")
+        assert not space.contains("Hello, world!")
+        assert flatdim(space) == 10
+        flattened_space = flatten_space(space)
+        assert isinstance(flattened_space, Box)
+        x = "baca"
+        flattened_x = flatten(space, x)
+        assert np.all(flattened_x == np.array([1, 0, 2, 0] + [3] * 6))
         assert x == unflatten(space, flattened_x)


### PR DESCRIPTION
# Description

* Added a Unicode space, which acts like the Text space but supports arbitrary Unicode characters.
  - The character set is still used in the `sample()` method, since it is difficult to sample from the entire Unicode character set.
* Reverted environments that contain Unicode characters.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
