### PR TITLE
Reward processors

### DIFF
--- a/docs/content/reward.md
+++ b/docs/content/reward.md
@@ -1,0 +1,28 @@
+# Reward
+
+In all environments, the reward is 0 during the episode, and a value in the range -1 to 1 (inclusive)
+when the episode terminates.
+
+## Reward processor
+
+Originally, any positive reward is scaled by the remaining time on the timer.
+Some environments also give partial rewards for partially correct answers
+(see the documentation or docstring of each environment for details).
+
+A **reward processor** can be used to returns custom rewards that ignore
+the time penalty or partial rewards. A reward processor can be specified during
+environment initialization:
+
+```python
+import gymnasium
+from miniwob.reward import get_binary_reward
+
+env = gymnasium.make('miniwob/ascending-numbers-v1', reward_processor=get_binary_reward)
+```
+
+The available reward processors include:
+
+* `get_original_reward`: Returns the original reward. This is the default.
+* `get_raw_reward`: Returns the raw reward without time penalty.
+* `get_binary_reward`: Returns the binary reward without time penalty or partial reward. The terminal reward will be either -1 or 1. This is used in most previous publications.
+* `get_thresholded_reward`: Returns the binary reward without time penalty or partial reward, but with any partial reward &geq; the specified threshold being treated as 1. This is needed for tasks that give continuous-valued partial rewards depending on how close the answer is to the correct answer. To specify this method as the reward processor, use `lambda metadata: get_thresholded_reward(metadata, threshold=VALUE)` or `functools.partial(get_thresholded_reward, threshold=VALUE)`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -55,6 +55,7 @@ content/basic_usage
 
 content/observation_space
 content/action_space
+content/reward
 ```
 
 ```{toctree}

--- a/miniwob/environment.py
+++ b/miniwob/environment.py
@@ -9,7 +9,7 @@ from miniwob.action import Action, ActionSpaceConfig, ActionTypes
 from miniwob.fields import FieldExtractor
 from miniwob.instance import MiniWoBInstance
 from miniwob.observation import Observation, get_observation_space
-from miniwob.reward import RewardPreprocessor
+from miniwob.reward import RewardProcessor
 
 
 class MiniWoBEnvironment(gym.Env):
@@ -28,7 +28,7 @@ class MiniWoBEnvironment(gym.Env):
         base_url: Optional[str] = None,
         action_space_config: Union[str, ActionSpaceConfig] = "all_supported",
         field_extractor: Optional[FieldExtractor] = None,
-        reward_processor: Optional[RewardPreprocessor] = None,
+        reward_processor: Optional[RewardProcessor] = None,
         wait_ms: float = 0.0,
         block_on_reset: bool = True,
         refresh_freq: int = 0,

--- a/miniwob/envs/flightwob_envs.py
+++ b/miniwob/envs/flightwob_envs.py
@@ -23,9 +23,10 @@ class FlightAAEnv(MiniWoBEnvironment):
     * Returning Day
     * Returning Month
 
-    ## Custom settings
+    ## Additional notes
 
-    None
+    * **Partial reward:** If all required fields are filled, the partial reward is the fraction of correct fields.
+    * The instructions come from a fixed set from the original FlightWoB dataset. Use the `set_data_mode` method of the environment to switch between the train and test scenarios.
     """
 
     subdomain = "flight.AA"
@@ -50,6 +51,11 @@ class FlightAlaskaEnv(MiniWoBEnvironment):
     * One Way or Round Trip
     * Returning Day
     * Returning Month
+
+    ## Additional notes
+
+    * **Partial reward:** If all required fields are filled, the partial reward is the fraction of correct fields.
+    * The instructions come from a fixed set from the original FlightWoB dataset. Use the `set_data_mode` method of the environment to switch between the train and test scenarios.
     """
 
     subdomain = "flight.Alaska"
@@ -74,6 +80,11 @@ class FlightAlaskaAutoEnv(MiniWoBEnvironment):
     * Returning Day
     * Seat type
     * Ticket Type
+
+    ## Additional notes
+
+    * **Partial reward:** If all required fields are filled, the partial reward is the fraction of correct fields.
+    * The instructions are automatically generated.
     """
 
     subdomain = "flight.Alaska-auto"

--- a/miniwob/envs/miniwob_envs.py
+++ b/miniwob/envs/miniwob_envs.py
@@ -16,6 +16,10 @@ class AscendingNumbersEnv(MiniWoBEnvironment):
     ## Utterance fields
 
     (none)
+
+    ## Additional notes
+
+    * **Partial reward:** If the first number is correctly clicked, the partial reward is 1 - fraction of remaining numbers.
     """
 
     subdomain = "ascending-numbers"
@@ -34,6 +38,11 @@ class BisectAngleEnv(MiniWoBEnvironment):
     ## Utterance fields
 
     (none)
+
+    ## Additional notes
+
+    * **Partial reward:** If the line is inside the angle, the partial reward is how close it is to the bisector (from 0 to 1).
+    * Since the reward is a continuous value, use the `get_thresholded_reward` reward preprocessor to binarize the reward instead of `get_binary_reward`.
     """
 
     subdomain = "bisect-angle"
@@ -105,6 +114,10 @@ class BuyTicketEnv(MiniWoBEnvironment):
     ## Utterance fields
 
     * target
+
+    ## Additional notes
+
+    * **Partial reward:** If the bought ticket is not the best but also not the worst according to the criterion, the partial reward is -0.5.
     """
 
     subdomain = "buy-ticket"
@@ -241,6 +254,11 @@ class CircleCenterEnv(MiniWoBEnvironment):
     ## Utterance fields
 
     (none)
+
+    ## Additional notes
+
+    * **Partial reward:** If the point is inside the circle, the partial reward is how close it is to the center (from 0 to 1).
+    * Since the reward is a continuous value, use the `get_thresholded_reward` reward preprocessor to binarize the reward instead of `get_binary_reward`.
     """
 
     subdomain = "circle-center"
@@ -263,6 +281,10 @@ class ClickButtonEnv(MiniWoBEnvironment):
     ## Utterance fields
 
     * target
+
+    ## Additional notes
+
+    * Clicking other non-buttons first is OK.
     """
 
     subdomain = "click-button"
@@ -307,6 +329,10 @@ class ClickCheckboxesEnv(MiniWoBEnvironment):
     * target 1
     * target 2
     * target 3
+
+    ## Additional notes
+
+    * **Partial reward:** The score is 1 for each correct checkbox and -1 for each incorrect one. The reward is the average score.
     """
 
     subdomain = "click-checkboxes"
@@ -341,6 +367,10 @@ class ClickCheckboxesLargeEnv(MiniWoBEnvironment):
     * target 7
     * target 8
     * target 9
+
+    ## Additional notes
+
+    * **Partial reward:** The score is 1 for each correct checkbox and -1 for each incorrect one. The reward is the average score.
     """
 
     subdomain = "click-checkboxes-large"
@@ -368,6 +398,10 @@ class ClickCheckboxesSoftEnv(MiniWoBEnvironment):
     * target 2
     * target 3
     * target 4
+
+    ## Additional notes
+
+    * **Partial reward:** The score is 1 for each correct checkbox and -1 for each incorrect one. The reward is the average score.
     """
 
     subdomain = "click-checkboxes-soft"
@@ -393,6 +427,11 @@ class ClickCheckboxesTransferEnv(MiniWoBEnvironment):
     * target 0
     * target 1
     * target 2
+
+    ## Additional notes
+
+    * **Partial reward:** The score is 1 for each correct checkbox and -1 for each incorrect one. The reward is the average score.
+    * Use the `set_data_mode` method of the environment to switch between the train and test scenarios.
     """
 
     subdomain = "click-checkboxes-transfer"
@@ -495,6 +534,10 @@ class ClickColorEnv(MiniWoBEnvironment):
     ## Utterance fields
 
     * target
+
+    ## Additional notes
+
+    * The utterance will have the color name transcribed.
     """
 
     subdomain = "click-color"
@@ -840,6 +883,10 @@ class ClickTab2MediumEnv(MiniWoBEnvironment):
     ## Utterance fields
 
     * target
+
+    ## Additional notes
+
+    * The second tab should only be clicked if the specified link is not in the current tab.
     """
 
     subdomain = "click-tab-2-medium"
@@ -894,6 +941,10 @@ class ClickTestTransferEnv(MiniWoBEnvironment):
     ## Utterance fields
 
     * target
+
+    ## Additional notes
+
+    * Use the `set_data_mode` method of the environment to switch between the train and test scenarios.
     """
 
     subdomain = "click-test-transfer"
@@ -934,6 +985,10 @@ class CopyPasteEnv(MiniWoBEnvironment):
     ## Utterance fields
 
     (none)
+
+    ## Additional notes
+
+    * The input is checked against the original content of the source textarea.
     """
 
     subdomain = "copy-paste"
@@ -954,6 +1009,10 @@ class CopyPaste2Env(MiniWoBEnvironment):
     ## Utterance fields
 
     * target
+
+    ## Additional notes
+
+    * The input is checked against the original content of the source textarea.
     """
 
     subdomain = "copy-paste-2"
@@ -1022,6 +1081,10 @@ class DailyCalendarEnv(MiniWoBEnvironment):
     * between to
     * length
     * name
+
+    ## Additional notes
+
+    * The created event must not overlap with existing events.
     """
 
     subdomain = "daily-calendar"
@@ -1083,6 +1146,10 @@ class DragCubeEnv(MiniWoBEnvironment):
     ## Utterance fields
 
     * target
+
+    ## Additional notes
+
+    * Non-deterministic: How much the cube moves depends on the mouse speed in real time.
     """
 
     subdomain = "drag-cube"
@@ -1169,6 +1236,10 @@ class DragShapes2Env(MiniWoBEnvironment):
     ## Utterance fields
 
     * target
+
+    ## Additional notes
+
+    * **Partial reward:** The reward is (1.3 x % correct) - (% incorrect), clipped to range -1 to 1.
     """
 
     subdomain = "drag-shapes-2"
@@ -1226,6 +1297,10 @@ class DrawCircleEnv(MiniWoBEnvironment):
     ## Utterance fields
 
     (none)
+
+    ## Additional notes
+
+    * **Partial reward:** The reward is -0.25 if the shape is too small. Otherwise the reward is based on how big the shape is and how consistent the circle radius is.
     """
 
     subdomain = "draw-circle"
@@ -1245,6 +1320,10 @@ class DrawLineEnv(MiniWoBEnvironment):
     ## Utterance fields
 
     * direction
+
+    ## Additional notes
+
+    * **Partial reward:** The reward is based on the line direction and the distance from the marked point.
     """
 
     subdomain = "draw-line"
@@ -1326,7 +1405,7 @@ class EmailInboxForwardNlEnv(MiniWoBEnvironment):
     """
     ## Description
 
-    [email-inbox-forward] NL instruction (30 templates).
+    [email-inbox-forward] varied instruction texts (30 templates).
 
     ## Example utterances
 
@@ -1340,6 +1419,10 @@ class EmailInboxForwardNlEnv(MiniWoBEnvironment):
 
     * by
     * to
+
+    ## Additional notes
+
+    * Test instruction templates are different from training one. Use the `set_data_mode` method of the environment to switch between the train and test templates.
     """
 
     subdomain = "email-inbox-forward-nl"
@@ -1349,7 +1432,7 @@ class EmailInboxForwardNlTurkEnv(MiniWoBEnvironment):
     """
     ## Description
 
-    [email-inbox-forward] NL instruction (100 templates).
+    [email-inbox-forward] varied instruction texts (100 templates).
 
     ## Example utterances
 
@@ -1363,6 +1446,10 @@ class EmailInboxForwardNlTurkEnv(MiniWoBEnvironment):
 
     * by
     * to
+
+    ## Additional notes
+
+    * Test instruction templates are different from training one. Use the `set_data_mode` method of the environment to switch between the train and test templates.
     """
 
     subdomain = "email-inbox-forward-nl-turk"
@@ -1395,7 +1482,7 @@ class EmailInboxNlTurkEnv(MiniWoBEnvironment):
     """
     ## Description
 
-    [email-inbox] NL instruction (100 templates for each subtask).
+    [email-inbox] varied instruction texts (100 templates for each subtask).
 
     ## Example utterances
 
@@ -1411,6 +1498,10 @@ class EmailInboxNlTurkEnv(MiniWoBEnvironment):
     * message
     * task
     * to
+
+    ## Additional notes
+
+    * Test instruction templates are different from training one. Use the `set_data_mode` method of the environment to switch between the train and test templates.
     """
 
     subdomain = "email-inbox-nl-turk"
@@ -1635,6 +1726,10 @@ class FindGreatestEnv(MiniWoBEnvironment):
     ## Utterance fields
 
     (none)
+
+    ## Additional notes
+
+    * **Partial reward:** If a card is open but it is not the greatest number, the partial reward is 0.1.
     """
 
     subdomain = "find-greatest"
@@ -1653,6 +1748,11 @@ class FindMidpointEnv(MiniWoBEnvironment):
     ## Utterance fields
 
     (none)
+
+    ## Additional notes
+
+    * **Partial reward:** If the point is at most 30px away from the midpoint, the partial reward is how close it is to the midpoint (from 0 to 1).
+    * Since the reward is a continuous value, use the `get_thresholded_reward` reward preprocessor to binarize the reward instead of `get_binary_reward`.
     """
 
     subdomain = "find-midpoint"
@@ -1847,6 +1947,10 @@ class GuessNumberEnv(MiniWoBEnvironment):
     ## Utterance fields
 
     (none)
+
+    ## Additional notes
+
+    * Can make as many guesses as needed.
     """
 
     subdomain = "guess-number"
@@ -1903,6 +2007,10 @@ class HotColdEnv(MiniWoBEnvironment):
     ## Utterance fields
 
     * target
+
+    ## Additional notes
+
+    * **Partial reward:** The partial reward is 0.5 for clicking a "warm" area, and 0.25 for a "cold" area.
     """
 
     subdomain = "hot-cold"
@@ -2077,6 +2185,10 @@ class OddOrEvenEnv(MiniWoBEnvironment):
     ## Utterance fields
 
     (none)
+
+    ## Additional notes
+
+    * **Partial reward:** The score for each number is 1 for correct, -1 for incorrect, and -0.25 for unselected. The final reward is the average score.
     """
 
     subdomain = "odd-or-even"
@@ -2126,6 +2238,10 @@ class PhoneBookEnv(MiniWoBEnvironment):
 
     * name
     * target
+
+    ## Additional notes
+
+    * **Partial reward:** The partial reward is 0.7 for the correct person and 0.3 for the correct contact type.
     """
 
     subdomain = "phone-book"
@@ -2205,6 +2321,10 @@ class RightAngleEnv(MiniWoBEnvironment):
     ## Utterance fields
 
     (none)
+
+    ## Additional notes
+
+    * **Partial reward:** If the angle is less than 45 degrees away from a right angle, the partial reward is how close it is to a right angle (from 0 to 1).
     """
 
     subdomain = "right-angle"
@@ -2499,6 +2619,10 @@ class TicTacToeEnv(MiniWoBEnvironment):
     ## Utterance fields
 
     (none)
+
+    ## Additional notes
+
+    * **Partial reward:** The partial reward is -0.5 for a draw and -0.75 for a loss (not finishing the game gives -1).
     """
 
     subdomain = "tic-tac-toe"
@@ -2589,6 +2713,11 @@ class UseColorwheelEnv(MiniWoBEnvironment):
     ## Utterance fields
 
     * target
+
+    ## Additional notes
+
+    * **Partial reward:** The reward is how far the chosen color is from the specified color.
+    * Since the reward is a continuous value, use the `get_thresholded_reward` reward preprocessor to binarize the reward instead of `get_binary_reward`.
     """
 
     subdomain = "use-colorwheel"
@@ -2607,6 +2736,11 @@ class UseColorwheel2Env(MiniWoBEnvironment):
     ## Utterance fields
 
     (none)
+
+    ## Additional notes
+
+    * **Partial reward:** The reward is how far the chosen color is from the specified color.
+    * Since the reward is a continuous value, use the `get_thresholded_reward` reward preprocessor to binarize the reward instead of `get_binary_reward`.
     """
 
     subdomain = "use-colorwheel-2"

--- a/miniwob/html/miniwob/click-checkboxes-large.html
+++ b/miniwob/html/miniwob/click-checkboxes-large.html
@@ -65,7 +65,7 @@ var genProblem = function() {
       var is_checked = d3.select('#ch'+i)[0][0].checked;
       r += is_checked === checkboxData.toclick[i] ? 1.0 : -1.0;
     }
-    core.endEpisode(r == checkboxData.elems ? 1.0 : -1.0, true);
+    core.endEpisode(r / checkboxData.elems, r > 0);
   });
 }
 

--- a/miniwob/html/miniwob/click-checkboxes-soft.html
+++ b/miniwob/html/miniwob/click-checkboxes-soft.html
@@ -100,7 +100,7 @@ var genProblem = function() {
       var is_checked = d3.select('#ch'+i)[0][0].checked;
       r += is_checked === checkboxData.toclick[i] ? 1.0 : -1.0;
     }
-    core.endEpisode(r == checkboxData.elems ? 1.0 : -1.0, true);
+    core.endEpisode(r / checkboxData.elems, r > 0);
   });
 }
 

--- a/miniwob/html/miniwob/click-checkboxes-transfer.html
+++ b/miniwob/html/miniwob/click-checkboxes-transfer.html
@@ -63,7 +63,7 @@ var genProblem = function() {
       var is_checked = d3.select('#ch'+i)[0][0].checked;
       r += is_checked === checkboxData.toclick[i] ? 1.0 : -1.0;
     }
-    core.endEpisode(r == checkboxData.elems ? 1.0 : -1.0, true);
+    core.endEpisode(r / checkboxData.elems, r > 0);
   });
 }
 

--- a/miniwob/html/miniwob/click-checkboxes.html
+++ b/miniwob/html/miniwob/click-checkboxes.html
@@ -54,7 +54,7 @@ var genProblem = function() {
       var is_checked = d3.select('#ch'+i)[0][0].checked;
       r += is_checked === checkboxData.toclick[i] ? 1.0 : -1.0;
     }
-    core.endEpisode(r == checkboxData.elems ? 1.0 : -1.0, true);
+    core.endEpisode(r / checkboxData.elems, r > 0);
   });
 }
 

--- a/miniwob/html/miniwob/count-sides.html
+++ b/miniwob/html/miniwob/count-sides.html
@@ -77,7 +77,7 @@ window.onload = function() {
 <div id="wrap">
   <div id="query">Press the button that correctly denotes how many sides the shape has.</div>
   <div id="area">
-    <canvas id="c"></canvas>
+    <canvas id="c" width="150" height="100"></canvas>
     <div id="form">
       <button data-sides="3">3</button>
       <button data-sides="4">4</button>

--- a/miniwob/html/miniwob/daily-calendar.html
+++ b/miniwob/html/miniwob/daily-calendar.html
@@ -353,7 +353,7 @@ var rewardEpisode = function(expectedAnswer){
 }
 
 var genProblem = function() {
-  $('#area').empty();
+  $('#area').empty().scrollTop(0);
 
   drawCalendar();
   renderRandomEvents();

--- a/miniwob/html/miniwob/sign-agreement.html
+++ b/miniwob/html/miniwob/sign-agreement.html
@@ -59,7 +59,7 @@ var signAndAgree = function(){
   $('#agree').on('click', function(){
     var userName = $('#name').val();
     var reward = expectedName === userName ? 1.0 : -1.0;
-    core.endEpisode(reward, true);
+    core.endEpisode(reward, reward > 0);
   });
 }
 
@@ -71,7 +71,7 @@ var signAndCancel = function(){
   $('#cancel').on('click', function(){
     var userName = $('#name').val();
     var reward = expectedName === userName ? 1.0 : -1.0;
-    core.endEpisode(reward, true);
+    core.endEpisode(reward, reward > 0);
   });
 }
 

--- a/miniwob/html/miniwob/unicode-test.html
+++ b/miniwob/html/miniwob/unicode-test.html
@@ -52,7 +52,7 @@ var genProblem = function() {
     if(e.html() === correct_text) {
       e.on('click', function(){ core.endEpisode(1.0, true, 'Cool!'); })
     } else {
-      e.on('click', function(){ core.endEpisode(-1.0, false, 'Well you clicked on ' + this.innerHTML + 'when you should have clicked on ' + correct_text + ', stupid agent!'); })
+      e.on('click', function(){ core.endEpisode(-1.0, false, 'You clicked on ' + this.innerHTML + ' when you should have clicked on ' + correct_text); })
     }
   }
 

--- a/miniwob/html/miniwob/use-colorwheel-2.html
+++ b/miniwob/html/miniwob/use-colorwheel-2.html
@@ -43,7 +43,7 @@ var genProblem = function() {
     var des = ui_utils.hexToRgb(col_desired);
 
     var r = 1.0 - (Math.abs(sel.r - des.r)/255.0 + Math.abs(sel.g - des.g)/255.0 + Math.abs(sel.b - des.b)/255.0)/3;
-    core.endEpisode(r, false);
+    core.endEpisode(r, r > 0);
   });
 }
 

--- a/miniwob/html/miniwob/use-colorwheel.html
+++ b/miniwob/html/miniwob/use-colorwheel.html
@@ -34,7 +34,7 @@ var genProblem = function() {
     var des = ui_utils.hexToRgb(col_desired);
 
     var r = 1.0 - (Math.abs(sel.r - des.r)/255.0 + Math.abs(sel.g - des.g)/255.0 + Math.abs(sel.b - des.b)/255.0)/3;
-    core.endEpisode(r, false);
+    core.endEpisode(r, r > 0);
   });
 }
 

--- a/miniwob/html/miniwob/use-spinner.html
+++ b/miniwob/html/miniwob/use-spinner.html
@@ -15,6 +15,7 @@
 <style>
 #area { padding: 5px; }
 #subbtn { margin-top: 5px; }
+#spinner { width: 90%; }
 </style>
 
 <script>

--- a/miniwob/instance.py
+++ b/miniwob/instance.py
@@ -36,7 +36,7 @@ from miniwob.observation import (
     create_empty_screenshot,
     create_observation,
 )
-from miniwob.reward import RewardPreprocessor, get_original_reward
+from miniwob.reward import RewardProcessor, get_original_reward
 from miniwob.screenshot import get_screenshot, pil_to_numpy_array
 
 
@@ -55,7 +55,7 @@ class MiniWoBInstance(Thread):
         base_url: Optional[str] = None,
         threading: bool = False,
         field_extractor: Optional[FieldExtractor] = None,
-        reward_processor: Optional[RewardPreprocessor] = None,
+        reward_processor: Optional[RewardProcessor] = None,
         wait_ms: float = 0.0,
         block_on_reset: bool = True,
         refresh_freq: int = 0,

--- a/miniwob/reward.py
+++ b/miniwob/reward.py
@@ -14,41 +14,37 @@ RewardPreprocessor = Callable[[Metadata], float]
 
 
 def get_original_reward(metadata: Metadata) -> float:
-    """Return the original reward with time penalty.
+    """Returns the original reward.
 
-    This is the reward as defined in the environment.
+    This is the reward as defined in the environment. In most environments,
+    this reward is scaled by the fraction of remaining time. Some environments
+    also give partial rewards. See the documentation or docstring of each
+    environment for details.
+
+    The returned value is 0.0 if the episode has not terminated yet,
+    and a value between -1.0 and 1.0 (inclusive) otherwise.
     """
     return float(metadata["env_reward"])
 
 
 def get_raw_reward(metadata: Metadata) -> float:
-    """Return the raw reward without time penalty.
+    """Returns the raw reward without time penalty.
 
-    This is usually 1 for success and -1 for failure, but not always.
+    Some environments still give partial rewards. See the documentation
+    or docstring of each environment for details.
+
+    The returned value is 0.0 if the episode has not terminated yet,
+    and a value between -1.0 and 1.0 (inclusive) otherwise.
     """
     return float(metadata["raw_reward"])
 
 
-def get_click_checkboxes_hard(metadata: Metadata) -> float:
-    """Return the reward without partial credits.
+def get_binary_reward(metadata: Metadata) -> float:
+    """Returns the reward without time penalty or partial credits.
 
-    This can be applied when the original environment gives partial credits
-    in addition to the time penalty (e.g., click-checkboxes).
-    Give 1 if the raw reward is 1. Otherwise, give -1.
+    The returned value is 0.0 if the episode has not terminated yet,
+    and either -1.0 or 1.0 otherwise.
     """
     if not metadata["done"]:
         return 0.0
     return 1.0 if metadata["raw_reward"] == 1.0 else -1.0
-
-
-def raw_reward_threshold(threshold: float) -> RewardPreprocessor:
-    """Return a reward processor that cut off at a threshold."""
-
-    def fn(metadata: Metadata) -> float:
-        if metadata["raw_reward"] > threshold:
-            return 1.0
-        elif metadata["raw_reward"] > 0:
-            return -1
-        return metadata["raw_reward"]
-
-    return fn

--- a/miniwob/reward.py
+++ b/miniwob/reward.py
@@ -16,8 +16,8 @@ RewardPreprocessor = Callable[[Metadata], float]
 def get_original_reward(metadata: Metadata) -> float:
     """Returns the original reward.
 
-    This is the reward as defined in the environment. In most environments,
-    this reward is scaled by the fraction of remaining time. Some environments
+    This is the reward as defined in the environment. In all environments,
+    any positive reward is scaled by the remaining time. Some environments
     also give partial rewards. See the documentation or docstring of each
     environment for details.
 
@@ -30,8 +30,8 @@ def get_original_reward(metadata: Metadata) -> float:
 def get_raw_reward(metadata: Metadata) -> float:
     """Returns the raw reward without time penalty.
 
-    Some environments still give partial rewards. See the documentation
-    or docstring of each environment for details.
+    Some environments give partial rewards. See the documentation or docstring
+    of each environment for details.
 
     The returned value is 0.0 if the episode has not terminated yet,
     and a value between -1.0 and 1.0 (inclusive) otherwise.
@@ -40,7 +40,7 @@ def get_raw_reward(metadata: Metadata) -> float:
 
 
 def get_binary_reward(metadata: Metadata) -> float:
-    """Returns the reward without time penalty or partial credits.
+    """Returns the reward without time penalty or partial reward.
 
     The returned value is 0.0 if the episode has not terminated yet,
     and either -1.0 or 1.0 otherwise.

--- a/miniwob/reward.py
+++ b/miniwob/reward.py
@@ -40,7 +40,7 @@ def get_raw_reward(metadata: Metadata) -> float:
 
 
 def get_binary_reward(metadata: Metadata) -> float:
-    """Returns the reward without time penalty or partial reward.
+    """Returns the binary reward without time penalty or partial reward.
 
     The returned value is 0.0 if the episode has not terminated yet,
     and either -1.0 or 1.0 otherwise.
@@ -48,3 +48,21 @@ def get_binary_reward(metadata: Metadata) -> float:
     if not metadata["done"]:
         return 0.0
     return 1.0 if metadata["raw_reward"] == 1.0 else -1.0
+
+
+def get_thresholded_reward(metadata: Metadata, threshold: float = 1.0) -> float:
+    """Returns the binary reward where raw reward >= threshold is treated as 1.0.
+
+    This is needed for tasks that give continuous-valued partial rewards
+    depending on how close the answer is to the correct answer.
+
+    To specify this method as the RewardPreprocessor, use
+    `lambda metadata: get_thresholded_reward(metadata, threshold=VALUE)`
+    or `functools.partial(get_thresholded_reward, threshold=VALUE)`.
+
+    The returned value is 0.0 if the episode has not terminated yet,
+    and either -1.0 or 1.0 otherwise.
+    """
+    if not metadata["done"]:
+        return 0.0
+    return 1.0 if metadata["raw_reward"] >= threshold else -1.0

--- a/miniwob/reward.py
+++ b/miniwob/reward.py
@@ -10,7 +10,7 @@ from typing import Any, Callable, Mapping
 
 
 Metadata = Mapping[str, Any]
-RewardPreprocessor = Callable[[Metadata], float]
+RewardProcessor = Callable[[Metadata], float]
 
 
 def get_original_reward(metadata: Metadata) -> float:
@@ -56,7 +56,7 @@ def get_thresholded_reward(metadata: Metadata, threshold: float = 1.0) -> float:
     This is needed for tasks that give continuous-valued partial rewards
     depending on how close the answer is to the correct answer.
 
-    To specify this method as the RewardPreprocessor, use
+    To specify this method as the reward processor, use
     `lambda metadata: get_thresholded_reward(metadata, threshold=VALUE)`
     or `functools.partial(get_thresholded_reward, threshold=VALUE)`.
 


### PR DESCRIPTION
# Description

The rewards from MiniWoB environments have a time penalty and partial rewards, which might not always be desirable. A reward processor can be used to specify the type of reward to use. For example, `get_binary_reward` ignores the time penalty and partial rewards, thus yielding the pure task success rate.

* Revised the existing reward processors in `reward.py`. Also added tests and documentation.
* Added information about partial reward and other caveats to the environment docstrings.
* Fixed any reward bug in the actual environments.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update


# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
