### PR TITLE
Fix: Headless mode screenshot bug

### DIFF
--- a/miniwob/html/miniwob/click-test.html
+++ b/miniwob/html/miniwob/click-test.html
@@ -17,7 +17,7 @@
 var genProblem = function() {
   var w = core.randi(35, 100);
   var L = core.randi(0, 160 - w - 2);
-  var U = core.randi(0, 160 - w - 20);
+  var U = core.randi(0, 160 - w - 2);
 
   var btn = d3.select('#subbtn');
   btn.attr('style', 'margin-left:'+L+'px; margin-top:'+U+'px; width:'+w+'px; height:'+w+'px;');

--- a/miniwob/html/miniwob/click-test.html
+++ b/miniwob/html/miniwob/click-test.html
@@ -17,7 +17,7 @@
 var genProblem = function() {
   var w = core.randi(35, 100);
   var L = core.randi(0, 160 - w - 2);
-  var U = core.randi(0, 160 - w - 2);
+  var U = core.randi(0, 160 - w - 20);
 
   var btn = d3.select('#subbtn');
   btn.attr('style', 'margin-left:'+L+'px; margin-top:'+U+'px; width:'+w+'px; height:'+w+'px;');

--- a/miniwob/selenium_instance.py
+++ b/miniwob/selenium_instance.py
@@ -186,7 +186,6 @@ class SeleniumInstance(Thread):
             self.index
         )
         options = webdriver.ChromeOptions()
-        options.add_argument(f"window-size={self.window_width},{self.window_height}")
         if self.headless:
             options.add_argument("headless")
             options.add_argument("disable-gpu")


### PR DESCRIPTION
<h2>Description</h2>
<p>This change removes the hard-coded <code inline="">window-size</code> argument in headless mode when instantiating the Chrome WebDriver, allowing Chrome’s default viewport to match the MiniWoB canvas size exactly. That eliminates the 30 px black padding at the bottom of screenshots and prevents <code inline="">MoveTargetOutOfBoundsException</code> errors when clicking near the lower edge of the task window.</p>
<p>Fixes #94</p>
<hr>
<h2>Type of change</h2>
<ul class="contains-task-list">
<li class="task-list-item">
<p><input type="checkbox" checked="" disabled=""> Bug fix (non-breaking change which fixes an issue)</p>
</li>
</ul>
<hr>
<h2>Screenshots</h2>

Before | After
![Screenshot from 2025-05-02 14-11-44](https://github.com/user-attachments/assets/7d512075-b725-4966-971e-dd4fa1e88d32) | ![Screenshot from 2025-05-02 14-12-33](https://github.com/user-attachments/assets/4b349946-8f82-4a5a-a2fd-e6338bc91e73)
<hr>
<h1>Checklist:</h1>
<ul class="contains-task-list">
<li class="task-list-item">
<p><input type="checkbox" checked="" disabled=""> I have run the <code inline="">pre-commit</code> checks with <code inline="">pre-commit run --all-files</code></p>
</li>
<li class="task-list-item">
<p><input type="checkbox" checked="" disabled=""> I have commented my code, particularly in hard-to-understand areas</p>
</li>
<li class="task-list-item">
<p><input type="checkbox" checked="" disabled=""> I have made corresponding changes to the documentation where necessary</p>
</li>
<li class="task-list-item">
<p><input type="checkbox" checked="" disabled=""> My changes generate no new warnings</p>
</li>
<li class="task-list-item">
<p><input type="checkbox" checked="" disabled=""> I have added tests that prove my fix is effective</p>
</li>
<li class="task-list-item">
<p><input type="checkbox" checked="" disabled=""> New and existing unit tests pass locally with my changes</p>
</li>
</ul>
<hr>
</body></html>