### PR TITLE
Fix find-greatest returning positive reward for wrong card selection

### DIFF
--- a/miniwob/html/miniwob/find-greatest.html
+++ b/miniwob/html/miniwob/find-greatest.html
@@ -76,7 +76,7 @@ var genProblem = function() {
     if(d3.selectAll('.card.hidden')[0].length === 3) {core.endEpisode(-1.0, false); return;}
     var userIndex = d3.select('.card:not(.hidden)')[0][0].getAttribute('data-index');
     if(userIndex === expectedIndex.toString()) core.endEpisode(1.0, true);
-    else core.endEpisode(0.1, true);
+    else core.endEpisode(0.0, false);
   });
 }
 


### PR DESCRIPTION
## Summary

Fix the find-greatest task so that selecting and submitting a non-maximum card returns a non-positive terminal reward.

## Bug

```js
else core.endEpisode(0.1, true);  // Wrong: 0.1 positive reward for wrong answer
```

Downstream wrappers like BrowserGym use `reward = float(info['RAW_REWARD_GLOBAL'] > 0)`, so wrong-card cases with reward 0.1 are treated as task success.

## Fix

```js
else core.endEpisode(0.0, false);  // Clear failure signal
```

Fixes #108