### PR TITLE
Enable docs versioning on miniwob.farama.org

### DIFF
--- a/.github/workflows/build-docs-version.yml
+++ b/.github/workflows/build-docs-version.yml
@@ -1,15 +1,20 @@
-name: Build main branch documentation website
+name: Build release documentation website
+
 on:
   push:
-    branches: [main]
+    tags:
+      - 'v?*.*.*'
+
 permissions:
   contents: write
+
 jobs:
   docs:
-    name: Generate Website
+    name: Generate Website for new version
     runs-on: ubuntu-latest
     env:
       SPHINX_GITHUB_CHANGELOG_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
     steps:
       - uses: actions/checkout@v3
 
@@ -41,9 +46,18 @@ jobs:
       - name: Remove .doctrees
         run: rm -r _build/.doctrees
 
-      - name: Upload to GitHub Pages
+      - name: Upload to GitHub Pages (versioned)
         uses: JamesIves/github-pages-deploy-action@v4
         with:
           folder: _build
-          target-folder: main
+          target-folder: ${{ github.ref_name }}
           clean: false
+
+      - name: Upload to GitHub Pages (latest at root)
+        uses: JamesIves/github-pages-deploy-action@v4
+        if: ${{ !contains(github.ref_name, 'a') }}
+        with:
+          folder: _build
+          clean-exclude: |
+            *.*.*/
+            main


### PR DESCRIPTION
## Problem

miniwob.farama.org is built with the Farama version-selector theme (its pages fetch `/main/_static/versioning/versioning_menu.html`), but `build-docs.yml` deploys the build to the **root** of `gh-pages` (`folder: _build`, no `target-folder`). So there is no `/main/` directory, the menu fetch 404s, and the dropdown never loads. There is also no release workflow, so no `/<version>/` folders exist.

## Change

Mirror the Gymnasium setup:

- **`build-docs.yml`** (push to `main`): add `target-folder: main` + `clean: false` so main docs publish under `/main/` without wiping sibling version folders.
- **`build-docs-version.yml`** (new, on `v?*.*.*` tags): reuses this repo's own build steps (`gen_mds.py`, `gen_env_list.py`, `sphinx-build -b dirhtml`, the 404 steps), then deploys to `/<tag>/` (`clean: false`) and copies the latest non-alpha release to root (`clean-exclude` preserves `*.*.*/` and `main`).

## Notes

- **No historical back-fill** — versions accumulate forward from the next release (same approach Gymnasium used). Until then the dropdown shows just `main`.
- After merge, the next release populates the site root; until then the bare root keeps serving the previous build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)