### PR TITLE
Mark nondeterministic environments with sources of nondeterminism and add test wrapper to absorb benign sources of nondeterminism

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,4 +18,4 @@ jobs:
              --build-arg PYTHON_VERSION=${{ matrix.python-version }} \
              --tag miniwob-plusplus-docker .
       - name: Run tests
-        run: docker run --shm-size=256m miniwob-plusplus-docker pytest --timeout=20
+        run: docker run --shm-size=256m miniwob-plusplus-docker pytest -v --timeout=20

--- a/docs/content/basic_usage.md
+++ b/docs/content/basic_usage.md
@@ -81,6 +81,17 @@ observation, info = env.reset(seed=42)
 observation, reward, terminated, truncated, info = env.step(action)
 ```
 
+```{warning}
+Not all MiniWoB++ environments are fully deterministic even when seeded.
+Sources of non-determinism include wall-clock-dependent rendering (focus rings,
+CSS animations), jQuery UI widget state that leaks across episode resets,
+variable `Math.random()` consumption in JS generation loops, and browser
+font-metric differences that affect layout.
+
+26 of 128 environments are registered with `nondeterministic=True` in Gymnasium.
+Please [submit a bug report](https://github.com/Farama-Foundation/miniwob-plusplus/issues/new/choose) if you find any new ones.
+```
+
 The [`reset`](https://gymnasium.farama.org/api/env/#gymnasium.Env.reset)
 and [`step`](https://gymnasium.farama.org/api/env/#gymnasium.Env.step) methods
 return an observation, which is a `dict` with the following fields:

--- a/miniwob/registration.py
+++ b/miniwob/registration.py
@@ -397,6 +397,7 @@ def register_miniwob_envs():
     register(
         id="miniwob/terminal-v1",
         entry_point="miniwob.envs.miniwob_envs:TerminalEnv",
+        nondeterministic=True,  # setInterval cursor flicker + new Date().toDateString() in DOM
     )
     register(
         id="miniwob/text-editor-v1",

--- a/miniwob/registration.py
+++ b/miniwob/registration.py
@@ -7,7 +7,6 @@ def register_miniwob_envs():
     register(
         id="miniwob/bisect-angle-v1",
         entry_point="miniwob.envs.miniwob_envs:BisectAngleEnv",
-        nondeterministic=True,
     )
     register(
         id="miniwob/book-flight-v1",
@@ -307,7 +306,6 @@ def register_miniwob_envs():
     register(
         id="miniwob/focus-text-2-v1",
         entry_point="miniwob.envs.miniwob_envs:FocusText2Env",
-        nondeterministic=True,
     )
     register(
         id="miniwob/grid-coordinate-v1",
@@ -373,7 +371,6 @@ def register_miniwob_envs():
     register(
         id="miniwob/scroll-text-v1",
         entry_point="miniwob.envs.miniwob_envs:ScrollTextEnv",
-        nondeterministic=True,
     )
     register(
         id="miniwob/scroll-text-2-v1",
@@ -428,7 +425,6 @@ def register_miniwob_envs():
     register(
         id="miniwob/use-autocomplete-v1",
         entry_point="miniwob.envs.miniwob_envs:UseAutocompleteEnv",
-        nondeterministic=True,
     )
     register(
         id="miniwob/use-autocomplete-nodelay-v1",

--- a/miniwob/registration.py
+++ b/miniwob/registration.py
@@ -21,18 +21,22 @@ def register_miniwob_envs():
     register(
         id="miniwob/choose-date-v1",
         entry_point="miniwob.envs.miniwob_envs:ChooseDateEnv",
+        nondeterministic=True,  # jQuery datepicker state persists across resets; showAnim fade
     )
     register(
         id="miniwob/choose-date-easy-v1",
         entry_point="miniwob.envs.miniwob_envs:ChooseDateEasyEnv",
+        nondeterministic=True,  # jQuery datepicker state persists across resets; showAnim fade
     )
     register(
         id="miniwob/choose-date-medium-v1",
         entry_point="miniwob.envs.miniwob_envs:ChooseDateMediumEnv",
+        nondeterministic=True,  # jQuery datepicker state persists across resets; showAnim fade
     )
     register(
         id="miniwob/choose-date-nodelay-v1",
         entry_point="miniwob.envs.miniwob_envs:ChooseDateNodelayEnv",
+        nondeterministic=True,  # jQuery datepicker state persists across resets
     )
     register(
         id="miniwob/choose-list-v1",
@@ -92,10 +96,12 @@ def register_miniwob_envs():
     register(
         id="miniwob/click-dialog-v1",
         entry_point="miniwob.envs.miniwob_envs:ClickDialogEnv",
+        nondeterministic=True,  # (Guess) jQuery UI dialog destroy/recreate cycle may desync Math.random stream
     )
     register(
         id="miniwob/click-dialog-2-v1",
         entry_point="miniwob.envs.miniwob_envs:ClickDialog2Env",
+        nondeterministic=True,  # (Guess) jQuery UI dialog destroy/recreate cycle may desync Math.random stream
     )
     register(
         id="miniwob/click-link-v1",
@@ -201,6 +207,7 @@ def register_miniwob_envs():
     register(
         id="miniwob/drag-cube-v1",
         entry_point="miniwob.envs.miniwob_envs:DragCubeEnv",
+        nondeterministic=True,  # setInterval physics loop; torque not cleared on reset
     )
     register(
         id="miniwob/drag-items-v1",
@@ -363,14 +370,17 @@ def register_miniwob_envs():
     register(
         id="miniwob/scroll-text-v1",
         entry_point="miniwob.envs.miniwob_envs:ScrollTextEnv",
+        nondeterministic=True,  # (Guess) textarea/input focus state not reset; caret captured in screenshot
     )
     register(
         id="miniwob/scroll-text-2-v1",
         entry_point="miniwob.envs.miniwob_envs:ScrollText2Env",
+        nondeterministic=True,  # scrollHeight-dependent scrollTop varies with font rendering
     )
     register(
         id="miniwob/search-engine-v1",
         entry_point="miniwob.envs.miniwob_envs:SearchEngineEnv",
+        nondeterministic=True,  # (Guess) twbsPagination plugin state leaks after Search click (.empty() before destroy)
     )
     register(
         id="miniwob/simple-algebra-v1",
@@ -393,6 +403,7 @@ def register_miniwob_envs():
     register(
         id="miniwob/social-media-some-v1",
         entry_point="miniwob.envs.miniwob_envs:SocialMediaSomeEnv",
+        nondeterministic=True,  # scrollTop() getter doesn't reset feed scroll between episodes
     )
     register(
         id="miniwob/terminal-v1",
@@ -520,6 +531,7 @@ def register_miniwob_envs():
     register(
         id="miniwob/order-food-v1",
         entry_point="miniwob.envs.miniwob_envs:OrderFoodEnv",
+        nondeterministic=True,  # scrollTop() getter doesn't reset food menu scroll between episodes
     )
     register(
         id="miniwob/phone-book-v1",

--- a/miniwob/registration.py
+++ b/miniwob/registration.py
@@ -11,12 +11,12 @@ def register_miniwob_envs():
     register(
         id="miniwob/book-flight-v1",
         entry_point="miniwob.envs.miniwob_envs:BookFlightEnv",
-        nondeterministic=True,
+        nondeterministic=True,  # datepicker "today" highlight + toLocaleTimeString() + screenshot jitter
     )
     register(
         id="miniwob/book-flight-nodelay-v1",
         entry_point="miniwob.envs.miniwob_envs:BookFlightNodelayEnv",
-        nondeterministic=True,
+        nondeterministic=True,  # datepicker "today" highlight + toLocaleTimeString() + screenshot jitter
     )
     register(
         id="miniwob/choose-date-v1",
@@ -45,6 +45,7 @@ def register_miniwob_envs():
     register(
         id="miniwob/click-button-v1",
         entry_point="miniwob.envs.miniwob_envs:ClickButtonEnv",
+        nondeterministic=True,  # focus ring on form element captured in screenshot
     )
     register(
         id="miniwob/click-button-sequence-v1",
@@ -57,7 +58,6 @@ def register_miniwob_envs():
     register(
         id="miniwob/click-checkboxes-large-v1",
         entry_point="miniwob.envs.miniwob_envs:ClickCheckboxesLargeEnv",
-        nondeterministic=True,
     )
     register(
         id="miniwob/click-checkboxes-soft-v1",
@@ -66,26 +66,24 @@ def register_miniwob_envs():
     register(
         id="miniwob/click-checkboxes-transfer-v1",
         entry_point="miniwob.envs.miniwob_envs:ClickCheckboxesTransferEnv",
+        nondeterministic=True,  # focus ring on form element captured in screenshot
     )
     register(
         id="miniwob/click-collapsible-v1",
         entry_point="miniwob.envs.miniwob_envs:ClickCollapsibleEnv",
-        nondeterministic=True,
+        nondeterministic=True,  # accordion animation race with focus() on submit button
     )
     register(
         id="miniwob/click-collapsible-2-v1",
         entry_point="miniwob.envs.miniwob_envs:ClickCollapsible2Env",
-        nondeterministic=True,
     )
     register(
         id="miniwob/click-collapsible-2-nodelay-v1",
         entry_point="miniwob.envs.miniwob_envs:ClickCollapsible2NodelayEnv",
-        nondeterministic=True,
     )
     register(
         id="miniwob/click-collapsible-nodelay-v1",
         entry_point="miniwob.envs.miniwob_envs:ClickCollapsibleNodelayEnv",
-        nondeterministic=True,
     )
     register(
         id="miniwob/click-color-v1",
@@ -94,12 +92,10 @@ def register_miniwob_envs():
     register(
         id="miniwob/click-dialog-v1",
         entry_point="miniwob.envs.miniwob_envs:ClickDialogEnv",
-        nondeterministic=True,
     )
     register(
         id="miniwob/click-dialog-2-v1",
         entry_point="miniwob.envs.miniwob_envs:ClickDialog2Env",
-        nondeterministic=True,
     )
     register(
         id="miniwob/click-link-v1",
@@ -112,7 +108,6 @@ def register_miniwob_envs():
     register(
         id="miniwob/click-menu-2-v1",
         entry_point="miniwob.envs.miniwob_envs:ClickMenu2Env",
-        nondeterministic=True,
     )
     register(
         id="miniwob/click-option-v1",
@@ -121,17 +116,17 @@ def register_miniwob_envs():
     register(
         id="miniwob/click-pie-v1",
         entry_point="miniwob.envs.miniwob_envs:ClickPieEnv",
-        nondeterministic=True,
+        nondeterministic=True,  # variable RNG consumption in arc generation
     )
     register(
         id="miniwob/click-pie-nodelay-v1",
         entry_point="miniwob.envs.miniwob_envs:ClickPieNodelayEnv",
-        nondeterministic=True,
+        nondeterministic=True,  # variable RNG consumption in arc generation
     )
     register(
         id="miniwob/click-scroll-list-v1",
         entry_point="miniwob.envs.miniwob_envs:ClickScrollListEnv",
-        nondeterministic=True,
+        nondeterministic=True,  # retry-loop RNG desync + native select layout
     )
     register(
         id="miniwob/click-shades-v1",
@@ -144,27 +139,22 @@ def register_miniwob_envs():
     register(
         id="miniwob/click-tab-v1",
         entry_point="miniwob.envs.miniwob_envs:ClickTabEnv",
-        nondeterministic=True,
     )
     register(
         id="miniwob/click-tab-2-v1",
         entry_point="miniwob.envs.miniwob_envs:ClickTab2Env",
-        nondeterministic=True,
     )
     register(
         id="miniwob/click-tab-2-easy-v1",
         entry_point="miniwob.envs.miniwob_envs:ClickTab2EasyEnv",
-        nondeterministic=True,
     )
     register(
         id="miniwob/click-tab-2-hard-v1",
         entry_point="miniwob.envs.miniwob_envs:ClickTab2HardEnv",
-        nondeterministic=True,
     )
     register(
         id="miniwob/click-tab-2-medium-v1",
         entry_point="miniwob.envs.miniwob_envs:ClickTab2MediumEnv",
-        nondeterministic=True,
     )
     register(
         id="miniwob/click-test-v1",
@@ -181,10 +171,12 @@ def register_miniwob_envs():
     register(
         id="miniwob/click-widget-v1",
         entry_point="miniwob.envs.miniwob_envs:ClickWidgetEnv",
+        nondeterministic=True,  # focus ring on form element captured in screenshot
     )
     register(
         id="miniwob/copy-paste-v1",
         entry_point="miniwob.envs.miniwob_envs:CopyPasteEnv",
+        nondeterministic=True,  # focus ring on form element captured in screenshot
     )
     register(
         id="miniwob/copy-paste-2-v1",
@@ -209,7 +201,6 @@ def register_miniwob_envs():
     register(
         id="miniwob/drag-cube-v1",
         entry_point="miniwob.envs.miniwob_envs:DragCubeEnv",
-        nondeterministic=True,
     )
     register(
         id="miniwob/drag-items-v1",
@@ -338,7 +329,7 @@ def register_miniwob_envs():
     register(
         id="miniwob/multi-layouts-v1",
         entry_point="miniwob.envs.miniwob_envs:MultiLayoutsEnv",
-        nondeterministic=True,
+        nondeterministic=True,  # focus ring on form element captured in screenshot
     )
     register(
         id="miniwob/multi-orderings-v1",
@@ -363,6 +354,7 @@ def register_miniwob_envs():
     register(
         id="miniwob/resize-textarea-v1",
         entry_point="miniwob.envs.miniwob_envs:ResizeTextareaEnv",
+        nondeterministic=True,  # focus ring on form element captured in screenshot
     )
     register(
         id="miniwob/right-angle-v1",
@@ -375,7 +367,6 @@ def register_miniwob_envs():
     register(
         id="miniwob/scroll-text-2-v1",
         entry_point="miniwob.envs.miniwob_envs:ScrollText2Env",
-        nondeterministic=True,
     )
     register(
         id="miniwob/search-engine-v1",
@@ -392,10 +383,12 @@ def register_miniwob_envs():
     register(
         id="miniwob/social-media-v1",
         entry_point="miniwob.envs.miniwob_envs:SocialMediaEnv",
+        nondeterministic=True,  # scrollTop() getter doesn't reset feed scroll between episodes
     )
     register(
         id="miniwob/social-media-all-v1",
         entry_point="miniwob.envs.miniwob_envs:SocialMediaAllEnv",
+        nondeterministic=True,  # scrollTop() getter doesn't reset feed scroll between episodes
     )
     register(
         id="miniwob/social-media-some-v1",
@@ -404,7 +397,6 @@ def register_miniwob_envs():
     register(
         id="miniwob/terminal-v1",
         entry_point="miniwob.envs.miniwob_envs:TerminalEnv",
-        nondeterministic=True,
     )
     register(
         id="miniwob/text-editor-v1",
@@ -458,17 +450,14 @@ def register_miniwob_envs():
     register(
         id="miniwob/flight.Alaska-v1",
         entry_point="miniwob.envs.flightwob_envs:FlightAlaskaEnv",
-        nondeterministic=True,
     )
     register(
         id="miniwob/flight.Alaska-auto-v1",
         entry_point="miniwob.envs.flightwob_envs:FlightAlaskaAutoEnv",
-        nondeterministic=True,
     )
     register(
         id="miniwob/flight.AA-v1",
         entry_point="miniwob.envs.flightwob_envs:FlightAAEnv",
-        nondeterministic=True,
     )
     # MiniWoB test set
     register(
@@ -486,7 +475,6 @@ def register_miniwob_envs():
     register(
         id="miniwob/drag-shapes-2-v1",
         entry_point="miniwob.envs.miniwob_envs:DragShapes2Env",
-        nondeterministic=True,
     )
     register(
         id="miniwob/drag-single-shape-v1",
@@ -495,7 +483,6 @@ def register_miniwob_envs():
     register(
         id="miniwob/draw-circle-v1",
         entry_point="miniwob.envs.miniwob_envs:DrawCircleEnv",
-        nondeterministic=True,
     )
     register(
         id="miniwob/draw-line-v1",
@@ -508,7 +495,6 @@ def register_miniwob_envs():
     register(
         id="miniwob/form-sequence-v1",
         entry_point="miniwob.envs.miniwob_envs:FormSequenceEnv",
-        nondeterministic=True,
     )
     register(
         id="miniwob/form-sequence-2-v1",
@@ -537,6 +523,7 @@ def register_miniwob_envs():
     register(
         id="miniwob/phone-book-v1",
         entry_point="miniwob.envs.miniwob_envs:PhoneBookEnv",
+        nondeterministic=True,  # twbsPagination plugin state leaks across resets
     )
     register(
         id="miniwob/sign-agreement-v1",
@@ -545,5 +532,5 @@ def register_miniwob_envs():
     register(
         id="miniwob/stock-market-v1",
         entry_point="miniwob.envs.miniwob_envs:StockMarketEnv",
-        nondeterministic=True,
+        nondeterministic=True,  # setInterval animation mutates DOM continuously
     )

--- a/miniwob/registration.py
+++ b/miniwob/registration.py
@@ -7,14 +7,17 @@ def register_miniwob_envs():
     register(
         id="miniwob/bisect-angle-v1",
         entry_point="miniwob.envs.miniwob_envs:BisectAngleEnv",
+        nondeterministic=True,
     )
     register(
         id="miniwob/book-flight-v1",
         entry_point="miniwob.envs.miniwob_envs:BookFlightEnv",
+        nondeterministic=True,
     )
     register(
         id="miniwob/book-flight-nodelay-v1",
         entry_point="miniwob.envs.miniwob_envs:BookFlightNodelayEnv",
+        nondeterministic=True,
     )
     register(
         id="miniwob/choose-date-v1",
@@ -55,6 +58,7 @@ def register_miniwob_envs():
     register(
         id="miniwob/click-checkboxes-large-v1",
         entry_point="miniwob.envs.miniwob_envs:ClickCheckboxesLargeEnv",
+        nondeterministic=True,
     )
     register(
         id="miniwob/click-checkboxes-soft-v1",
@@ -67,18 +71,22 @@ def register_miniwob_envs():
     register(
         id="miniwob/click-collapsible-v1",
         entry_point="miniwob.envs.miniwob_envs:ClickCollapsibleEnv",
+        nondeterministic=True,
     )
     register(
         id="miniwob/click-collapsible-2-v1",
         entry_point="miniwob.envs.miniwob_envs:ClickCollapsible2Env",
+        nondeterministic=True,
     )
     register(
         id="miniwob/click-collapsible-2-nodelay-v1",
         entry_point="miniwob.envs.miniwob_envs:ClickCollapsible2NodelayEnv",
+        nondeterministic=True,
     )
     register(
         id="miniwob/click-collapsible-nodelay-v1",
         entry_point="miniwob.envs.miniwob_envs:ClickCollapsibleNodelayEnv",
+        nondeterministic=True,
     )
     register(
         id="miniwob/click-color-v1",
@@ -87,10 +95,12 @@ def register_miniwob_envs():
     register(
         id="miniwob/click-dialog-v1",
         entry_point="miniwob.envs.miniwob_envs:ClickDialogEnv",
+        nondeterministic=True,
     )
     register(
         id="miniwob/click-dialog-2-v1",
         entry_point="miniwob.envs.miniwob_envs:ClickDialog2Env",
+        nondeterministic=True,
     )
     register(
         id="miniwob/click-link-v1",
@@ -103,6 +113,7 @@ def register_miniwob_envs():
     register(
         id="miniwob/click-menu-2-v1",
         entry_point="miniwob.envs.miniwob_envs:ClickMenu2Env",
+        nondeterministic=True,
     )
     register(
         id="miniwob/click-option-v1",
@@ -121,6 +132,7 @@ def register_miniwob_envs():
     register(
         id="miniwob/click-scroll-list-v1",
         entry_point="miniwob.envs.miniwob_envs:ClickScrollListEnv",
+        nondeterministic=True,
     )
     register(
         id="miniwob/click-shades-v1",
@@ -133,22 +145,27 @@ def register_miniwob_envs():
     register(
         id="miniwob/click-tab-v1",
         entry_point="miniwob.envs.miniwob_envs:ClickTabEnv",
+        nondeterministic=True,
     )
     register(
         id="miniwob/click-tab-2-v1",
         entry_point="miniwob.envs.miniwob_envs:ClickTab2Env",
+        nondeterministic=True,
     )
     register(
         id="miniwob/click-tab-2-easy-v1",
         entry_point="miniwob.envs.miniwob_envs:ClickTab2EasyEnv",
+        nondeterministic=True,
     )
     register(
         id="miniwob/click-tab-2-hard-v1",
         entry_point="miniwob.envs.miniwob_envs:ClickTab2HardEnv",
+        nondeterministic=True,
     )
     register(
         id="miniwob/click-tab-2-medium-v1",
         entry_point="miniwob.envs.miniwob_envs:ClickTab2MediumEnv",
+        nondeterministic=True,
     )
     register(
         id="miniwob/click-test-v1",
@@ -193,6 +210,7 @@ def register_miniwob_envs():
     register(
         id="miniwob/drag-cube-v1",
         entry_point="miniwob.envs.miniwob_envs:DragCubeEnv",
+        nondeterministic=True,
     )
     register(
         id="miniwob/drag-items-v1",
@@ -289,6 +307,7 @@ def register_miniwob_envs():
     register(
         id="miniwob/focus-text-2-v1",
         entry_point="miniwob.envs.miniwob_envs:FocusText2Env",
+        nondeterministic=True,
     )
     register(
         id="miniwob/grid-coordinate-v1",
@@ -321,6 +340,7 @@ def register_miniwob_envs():
     register(
         id="miniwob/multi-layouts-v1",
         entry_point="miniwob.envs.miniwob_envs:MultiLayoutsEnv",
+        nondeterministic=True,
     )
     register(
         id="miniwob/multi-orderings-v1",
@@ -353,10 +373,12 @@ def register_miniwob_envs():
     register(
         id="miniwob/scroll-text-v1",
         entry_point="miniwob.envs.miniwob_envs:ScrollTextEnv",
+        nondeterministic=True,
     )
     register(
         id="miniwob/scroll-text-2-v1",
         entry_point="miniwob.envs.miniwob_envs:ScrollText2Env",
+        nondeterministic=True,
     )
     register(
         id="miniwob/search-engine-v1",
@@ -406,6 +428,7 @@ def register_miniwob_envs():
     register(
         id="miniwob/use-autocomplete-v1",
         entry_point="miniwob.envs.miniwob_envs:UseAutocompleteEnv",
+        nondeterministic=True,
     )
     register(
         id="miniwob/use-autocomplete-nodelay-v1",
@@ -439,14 +462,17 @@ def register_miniwob_envs():
     register(
         id="miniwob/flight.Alaska-v1",
         entry_point="miniwob.envs.flightwob_envs:FlightAlaskaEnv",
+        nondeterministic=True,
     )
     register(
         id="miniwob/flight.Alaska-auto-v1",
         entry_point="miniwob.envs.flightwob_envs:FlightAlaskaAutoEnv",
+        nondeterministic=True,
     )
     register(
         id="miniwob/flight.AA-v1",
         entry_point="miniwob.envs.flightwob_envs:FlightAAEnv",
+        nondeterministic=True,
     )
     # MiniWoB test set
     register(
@@ -464,6 +490,7 @@ def register_miniwob_envs():
     register(
         id="miniwob/drag-shapes-2-v1",
         entry_point="miniwob.envs.miniwob_envs:DragShapes2Env",
+        nondeterministic=True,
     )
     register(
         id="miniwob/drag-single-shape-v1",
@@ -472,6 +499,7 @@ def register_miniwob_envs():
     register(
         id="miniwob/draw-circle-v1",
         entry_point="miniwob.envs.miniwob_envs:DrawCircleEnv",
+        nondeterministic=True,
     )
     register(
         id="miniwob/draw-line-v1",
@@ -484,6 +512,7 @@ def register_miniwob_envs():
     register(
         id="miniwob/form-sequence-v1",
         entry_point="miniwob.envs.miniwob_envs:FormSequenceEnv",
+        nondeterministic=True,
     )
     register(
         id="miniwob/form-sequence-2-v1",

--- a/miniwob/screenshot.py
+++ b/miniwob/screenshot.py
@@ -1,6 +1,7 @@
 """Screenshot utilities."""
 import json
 from io import BytesIO
+from typing import cast
 
 import numpy as np
 from PIL import Image, ImageCms, ImageDraw
@@ -41,7 +42,9 @@ def get_screenshot(
     if icc_profile:
         orig_icc = ImageCms.ImageCmsProfile(BytesIO(icc_profile))
         srgb_icc = ImageCms.createProfile("sRGB")
-        pil_image = ImageCms.profileToProfile(pil_image, orig_icc, srgb_icc)
+        pil_image = cast(
+            Image.Image, ImageCms.profileToProfile(pil_image, orig_icc, srgb_icc)
+        )
     return pil_image
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,4 +95,5 @@ filterwarnings = [
     'ignore:.*For Box action spaces, we recommend using a symmetric and normalized space.*',
     'ignore:.*No render fps was declared in the environment.*',
     'ignore::ResourceWarning',
+    'ignore:.*The environment.*is different from the unwrapped version.*',
 ]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -5,7 +5,7 @@ from gymnasium import spaces
 from gymnasium.utils.env_checker import check_env
 from gymnasium.wrappers import FlattenObservation
 
-from tests.utils import get_all_registered_miniwob_envs
+from tests.utils import StripNondeterministicInfo, get_all_registered_miniwob_envs
 
 
 class TestGymAPI:
@@ -21,7 +21,8 @@ class TestGymAPI:
     def test_gym_api(self, env):
         """Check that the environment follows Gym API."""
         # Run check_env to check space containment, determinism, etc.
-        check_env(env.unwrapped, skip_render_check=True)
+        # We use wrapper to strip wall-clock info key "elapsed" which broke determinism checks.
+        check_env(StripNondeterministicInfo(env.unwrapped), skip_render_check=True)
         # Check the spaces and flattened spaces.
         assert isinstance(env.observation_space, spaces.Dict)
         assert set(env.observation_space) == {

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -24,7 +24,7 @@ class TestGymAPI:
         # Run check_env to check space containment, determinism, etc.
         for i in range(1, 4):
             try:
-                # We use wrapper to strip wall-clock info key "elapsed" which broke determinism checks.
+                # We use wrapper to strip key "elapsed" & normalize DOM obs which broke determinism checks.
                 check_env(
                     StripNondeterministicInfo(env.unwrapped), skip_render_check=True
                 )

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -4,6 +4,7 @@ import pytest
 from gymnasium import spaces
 from gymnasium.utils.env_checker import check_env
 from gymnasium.wrappers import FlattenObservation
+from selenium.common.exceptions import MoveTargetOutOfBoundsException
 
 from tests.utils import StripNondeterministicInfo, get_all_registered_miniwob_envs
 
@@ -21,8 +22,16 @@ class TestGymAPI:
     def test_gym_api(self, env):
         """Check that the environment follows Gym API."""
         # Run check_env to check space containment, determinism, etc.
-        # We use wrapper to strip wall-clock info key "elapsed" which broke determinism checks.
-        check_env(StripNondeterministicInfo(env.unwrapped), skip_render_check=True)
+        for i in range(1, 4):
+            try:
+                # We use wrapper to strip wall-clock info key "elapsed" which broke determinism checks.
+                check_env(
+                    StripNondeterministicInfo(env.unwrapped), skip_render_check=True
+                )
+                break
+            except MoveTargetOutOfBoundsException as e:
+                # For random movements, this is kind of inevitable, so we give three chances.
+                print(f"\033[31m{env.unwrapped.spec.id} attempt {i} failed:\033[0m {e}")
         # Check the spaces and flattened spaces.
         assert isinstance(env.observation_space, spaces.Dict)
         assert set(env.observation_space) == {

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,7 +1,37 @@
 """Test utilities."""
 from collections.abc import Iterable
+from typing import Any
 
 import gymnasium
+from gymnasium.utils import RecordConstructorArgs
+
+
+NONDETERMINISTIC_INFO_KEYS = ("elapsed",)
+
+
+class StripNondeterministicInfo(gymnasium.Wrapper, RecordConstructorArgs):
+    """Wrapper that removes inherently non-deterministic keys from info dicts.
+
+    Wall-clock fields like ``elapsed`` break gymnasium's determinism checks
+    because they vary across runs even when the environment is seeded
+    identically.  This wrapper is intended for **test use only**.
+    """
+
+    def __init__(self, env: gymnasium.Env):
+        RecordConstructorArgs.__init__(self)
+        gymnasium.Wrapper.__init__(self, env)
+
+    def reset(self, *, seed: int | None = None, options: dict[str, Any] | None = None):
+        obs, info = self.env.reset(seed=seed, options=options)
+        for key in NONDETERMINISTIC_INFO_KEYS:
+            info.pop(key, None)
+        return obs, info
+
+    def step(self, action):
+        obs, reward, terminated, truncated, info = self.env.step(action)
+        for key in NONDETERMINISTIC_INFO_KEYS:
+            info.pop(key, None)
+        return obs, reward, terminated, truncated, info
 
 
 def get_all_registered_miniwob_envs() -> Iterable[str]:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,5 +1,7 @@
 """Test utilities."""
+import pickle
 from collections.abc import Iterable
+from pathlib import Path
 from typing import Any
 
 import gymnasium
@@ -8,75 +10,9 @@ from gymnasium.utils import RecordConstructorArgs
 
 
 NONDETERMINISTIC_INFO_KEYS = ("elapsed",)
-
 POSITION_DECIMALS = 1
-
-
-def _normalize_obs(obs: dict[str, Any]) -> dict[str, Any]:
-    """Normalize non-deterministic fields in a MiniWoB observation.
-
-    - Re-indexes ``ref`` / ``parent`` codes so they always start from 0.
-    - Rounds position floats (``left``, ``top``, ``width``, ``height``)
-      to avoid sub-pixel rendering drift.
-    """
-    dom_elements = obs.get("dom_elements")
-    if not dom_elements:
-        return obs
-
-    ref_map: dict[int, int] = {0: 0}
-    normalized = []
-    for elem in dom_elements:
-        elem = dict(elem)
-        old_ref = elem["ref"]
-        if old_ref not in ref_map:
-            ref_map[old_ref] = len(ref_map)
-        elem["ref"] = ref_map[old_ref]
-
-        old_parent = elem["parent"]
-        if old_parent not in ref_map:
-            ref_map[old_parent] = len(ref_map)
-        elem["parent"] = ref_map[old_parent]
-
-        for key in ("left", "top", "width", "height"):
-            if key in elem:
-                elem[key] = np.round(elem[key], decimals=POSITION_DECIMALS)
-
-        normalized.append(elem)
-
-    obs = dict(obs)
-    obs["dom_elements"] = tuple(normalized)
-    return obs
-
-
-class StripNondeterministicInfo(gymnasium.Wrapper, RecordConstructorArgs):
-    """Wrapper that normalizes non-deterministic observation and info fields.
-
-    Handles two framework-level sources of non-determinism:
-
-    1. Wall-clock fields like ``elapsed`` in the info dict.
-    2. Monotonically-increasing ``ref`` codes and sub-pixel position floats
-       from ``getBoundingClientRect()`` in observations.
-
-    This wrapper is intended for **test use only**.
-    """
-
-    def __init__(self, env: gymnasium.Env):
-        RecordConstructorArgs.__init__(self)
-        gymnasium.Wrapper.__init__(self, env)
-
-    def reset(self, *, seed: int | None = None, options: dict[str, Any] | None = None):
-        obs, info = self.env.reset(seed=seed, options=options)
-        obs = _normalize_obs(obs)
-        for key in NONDETERMINISTIC_INFO_KEYS:
-            info.pop(key, None)
-        return obs, info
-
-    def step(self, action):
-        obs, reward, terminated, truncated, info = self.env.step(action)
-        obs = _normalize_obs(obs)
-        for key in NONDETERMINISTIC_INFO_KEYS:
-            info.pop(key, None)
-        return obs, reward, terminated, truncated, info
+TAMPERED_FLAG_INDEX = 1
+SCREENSHOT_QUANTIZE_FACTOR = 8.0
 
 
 def get_all_registered_miniwob_envs() -> Iterable[str]:
@@ -86,3 +22,134 @@ def get_all_registered_miniwob_envs() -> Iterable[str]:
         if env_spec.namespace == "miniwob":
             envs.append(env_id)
     return sorted(envs)
+
+
+class StripNondeterministicInfo(gymnasium.Wrapper, RecordConstructorArgs):
+    """Wrapper that normalizes non-deterministic observation and info fields.
+
+    Handles framework-level sources of non-determinism:
+
+    1. Wall-clock fields like ``elapsed`` in the info dict.
+    2. Monotonically-increasing ``ref`` codes in DOM elements.
+    3. Sub-pixel position floats from ``getBoundingClientRect()``.
+    4. Timing-dependent ``tampered`` flag in DOM element flags.
+    5. Anti-aliasing / sub-pixel rendering jitter in screenshots.
+
+    This wrapper is intended for **test use only**.
+    """
+
+    def __init__(self, env: gymnasium.Env, data_collection: bool = False):
+        RecordConstructorArgs.__init__(self)
+        gymnasium.Wrapper.__init__(self, env)
+        self.data_collection = data_collection
+        self.observations: list[dict[str, Any]] = []
+
+    def reset(self, *, seed: int | None = None, options: dict[str, Any] | None = None):
+        obs, info = self.env.reset(seed=seed, options=options)
+        obs = _normalize_obs(obs)
+        if self.data_collection:
+            self.observations.append(
+                {
+                    "method": "reset",
+                    "seed": seed,
+                    "obs": obs,
+                    "info": {
+                        k: v
+                        for k, v in info.items()
+                        if k not in NONDETERMINISTIC_INFO_KEYS
+                    },
+                }
+            )
+        for key in NONDETERMINISTIC_INFO_KEYS:
+            info.pop(key, None)
+        return obs, info
+
+    def step(self, action):
+        obs, reward, terminated, truncated, info = self.env.step(action)
+        obs = _normalize_obs(obs)
+        if self.data_collection:
+            self.observations.append(
+                {
+                    "method": "step",
+                    "action": action,
+                    "obs": obs,
+                    "reward": reward,
+                    "terminated": terminated,
+                    "truncated": truncated,
+                    "info": {
+                        k: v
+                        for k, v in info.items()
+                        if k not in NONDETERMINISTIC_INFO_KEYS
+                    },
+                }
+            )
+        for key in NONDETERMINISTIC_INFO_KEYS:
+            info.pop(key, None)
+        return obs, reward, terminated, truncated, info
+
+    def dump(self, path: str, **extra):
+        """Dump recorded observations to a pickle file.
+
+        Args:
+            path: File path to write the pickle to.
+            **extra: Additional metadata to include in the dump.
+        """
+
+        data = {
+            "env_id": self.spec.id if self.spec else str(self.env),
+            "observations": self.observations,
+            **extra,
+        }
+        Path(path).parent.mkdir(parents=True, exist_ok=True)
+        with open(path, "wb") as f:
+            pickle.dump(data, f, protocol=5)
+
+
+def _normalize_obs(obs: dict[str, Any]) -> dict[str, Any]:
+    """Normalize non-deterministic fields in a MiniWoB observation.
+
+    - Re-indexes ``ref`` / ``parent`` codes so they always start from 0.
+    - Rounds position floats (``left``, ``top``, ``width``, ``height``)
+      to avoid sub-pixel rendering drift.
+    - Zeros the ``tampered`` flag which is timing-dependent (chrome's issue).
+    - Rounds screenshot pixels to the nearest ``SCREENSHOT_QUANTIZE_FACTOR``
+      to absorb anti-aliasing jitter.
+    """
+    obs = dict(obs)
+
+    dom_elements = obs.get("dom_elements")
+    if dom_elements:
+        ref_map: dict[int, int] = {0: 0}
+        normalized = []
+        for elem in dom_elements:
+            elem = dict(elem)
+            old_ref = elem["ref"]
+            if old_ref not in ref_map:
+                ref_map[old_ref] = len(ref_map)
+            elem["ref"] = ref_map[old_ref]
+
+            old_parent = elem["parent"]
+            if old_parent not in ref_map:
+                ref_map[old_parent] = len(ref_map)
+            elem["parent"] = ref_map[old_parent]
+
+            for key in ("left", "top", "width", "height"):
+                if key in elem:
+                    elem[key] = np.round(elem[key], decimals=POSITION_DECIMALS)
+
+            if "flags" in elem:
+                flags = elem["flags"].copy()
+                flags[TAMPERED_FLAG_INDEX] = 0
+                elem["flags"] = flags
+
+            normalized.append(elem)
+
+        obs["dom_elements"] = tuple(normalized)
+
+    screenshot = obs.get("screenshot")
+    if screenshot is not None and isinstance(screenshot, np.ndarray):
+        q_factor = SCREENSHOT_QUANTIZE_FACTOR
+        quantized = np.floor(screenshot.astype(np.float32) / q_factor + 0.5) * q_factor
+        obs["screenshot"] = np.clip(quantized, 0, 255).astype(np.uint8)
+
+    return obs

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -3,18 +3,61 @@ from collections.abc import Iterable
 from typing import Any
 
 import gymnasium
+import numpy as np
 from gymnasium.utils import RecordConstructorArgs
 
 
 NONDETERMINISTIC_INFO_KEYS = ("elapsed",)
 
+POSITION_DECIMALS = 1
+
+
+def _normalize_obs(obs: dict[str, Any]) -> dict[str, Any]:
+    """Normalize non-deterministic fields in a MiniWoB observation.
+
+    - Re-indexes ``ref`` / ``parent`` codes so they always start from 0.
+    - Rounds position floats (``left``, ``top``, ``width``, ``height``)
+      to avoid sub-pixel rendering drift.
+    """
+    dom_elements = obs.get("dom_elements")
+    if not dom_elements:
+        return obs
+
+    ref_map: dict[int, int] = {0: 0}
+    normalized = []
+    for elem in dom_elements:
+        elem = dict(elem)
+        old_ref = elem["ref"]
+        if old_ref not in ref_map:
+            ref_map[old_ref] = len(ref_map)
+        elem["ref"] = ref_map[old_ref]
+
+        old_parent = elem["parent"]
+        if old_parent not in ref_map:
+            ref_map[old_parent] = len(ref_map)
+        elem["parent"] = ref_map[old_parent]
+
+        for key in ("left", "top", "width", "height"):
+            if key in elem:
+                elem[key] = np.round(elem[key], decimals=POSITION_DECIMALS)
+
+        normalized.append(elem)
+
+    obs = dict(obs)
+    obs["dom_elements"] = tuple(normalized)
+    return obs
+
 
 class StripNondeterministicInfo(gymnasium.Wrapper, RecordConstructorArgs):
-    """Wrapper that removes inherently non-deterministic keys from info dicts.
+    """Wrapper that normalizes non-deterministic observation and info fields.
 
-    Wall-clock fields like ``elapsed`` break gymnasium's determinism checks
-    because they vary across runs even when the environment is seeded
-    identically.  This wrapper is intended for **test use only**.
+    Handles two framework-level sources of non-determinism:
+
+    1. Wall-clock fields like ``elapsed`` in the info dict.
+    2. Monotonically-increasing ``ref`` codes and sub-pixel position floats
+       from ``getBoundingClientRect()`` in observations.
+
+    This wrapper is intended for **test use only**.
     """
 
     def __init__(self, env: gymnasium.Env):
@@ -23,12 +66,14 @@ class StripNondeterministicInfo(gymnasium.Wrapper, RecordConstructorArgs):
 
     def reset(self, *, seed: int | None = None, options: dict[str, Any] | None = None):
         obs, info = self.env.reset(seed=seed, options=options)
+        obs = _normalize_obs(obs)
         for key in NONDETERMINISTIC_INFO_KEYS:
             info.pop(key, None)
         return obs, info
 
     def step(self, action):
         obs, reward, terminated, truncated, info = self.env.step(action)
+        obs = _normalize_obs(obs)
         for key in NONDETERMINISTIC_INFO_KEYS:
             info.pop(key, None)
         return obs, reward, terminated, truncated, info


### PR DESCRIPTION
# Description

1. Added a `StripNondeterministicInfo` wrapper in unit tests to strip out **benign** sources of nondeterminism such as wall-clock `elapsed` timing in the info dict, monotonically-increasing ref/parent codes in DOM elements, sub-pixel position floats from `getBoundingClientRect()`, the timing-dependent `tampered` flag, and anti-aliasing jitter in screenshots (quantized to nearest 8).
2. Added retries to `MoveTargetOutOfBoundsException` in unit tests, because that is inevitable.
3. Labelled 4 existing **nondeterministic** environments with reasons.
4. Added 25 new **nondeterministic** environments with reasons (4 were labelled with `(guess)` as the source of nondeterminism is unclear or unconfirmed).
5. Updated documentation with warning text about determinism within `MiniWoB++`.
6. Suppressed one typing warning in `get_screenshot` with `typing.cast`.

This should fix CI for now...

Fixes #110 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
