### PR TITLE
Correct number of nondeterministic environments in documentation

### DIFF
--- a/docs/content/basic_usage.md
+++ b/docs/content/basic_usage.md
@@ -83,12 +83,11 @@ observation, reward, terminated, truncated, info = env.step(action)
 
 ```{warning}
 Not all MiniWoB++ environments are fully deterministic even when seeded.
-Sources of non-determinism include wall-clock-dependent rendering (focus rings,
-CSS animations), jQuery UI widget state that leaks across episode resets,
-variable `Math.random()` consumption in JS generation loops, and browser
-font-metric differences that affect layout.
+Sources of non-determinism include wall-clock-dependent rendering (focus rings, CSS animations),
+jQuery UI widget state that leaks across episode resets, variable `Math.random()` consumption in
+JS generation loops, and browser font-metric differences that affect layout.
 
-26 of 128 environments are registered with `nondeterministic=True` in Gymnasium.
+29 out of 128 environments are registered with `nondeterministic=True` in Gymnasium.
 Please [submit a bug report](https://github.com/Farama-Foundation/miniwob-plusplus/issues/new/choose) if you find any new ones.
 ```
 


### PR DESCRIPTION
# Description

This was missed in #116's last commit.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

### Screenshots
Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |


To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

# Checklist:

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
