### PR TITLE
Use wait_ms to mitigate issues with focus ring & mark the FlightWoB environments as nondeterministic

### DIFF
--- a/docs/content/basic_usage.md
+++ b/docs/content/basic_usage.md
@@ -87,7 +87,7 @@ Sources of non-determinism include wall-clock-dependent rendering (focus rings, 
 jQuery UI widget state that leaks across episode resets, variable `Math.random()` consumption in
 JS generation loops, and browser font-metric differences that affect layout.
 
-37 out of 128 environments are registered with `nondeterministic=True` in Gymnasium.
+39 out of 128 environments are registered with `nondeterministic=True` in Gymnasium.
 Please [submit a bug report](https://github.com/Farama-Foundation/miniwob-plusplus/issues/new/choose) if you find any new ones.
 ```
 

--- a/docs/content/basic_usage.md
+++ b/docs/content/basic_usage.md
@@ -87,7 +87,7 @@ Sources of non-determinism include wall-clock-dependent rendering (focus rings, 
 jQuery UI widget state that leaks across episode resets, variable `Math.random()` consumption in
 JS generation loops, and browser font-metric differences that affect layout.
 
-32 out of 128 environments are registered with `nondeterministic=True` in Gymnasium.
+37 out of 128 environments are registered with `nondeterministic=True` in Gymnasium.
 Please [submit a bug report](https://github.com/Farama-Foundation/miniwob-plusplus/issues/new/choose) if you find any new ones.
 ```
 

--- a/docs/content/basic_usage.md
+++ b/docs/content/basic_usage.md
@@ -87,7 +87,7 @@ Sources of non-determinism include wall-clock-dependent rendering (focus rings, 
 jQuery UI widget state that leaks across episode resets, variable `Math.random()` consumption in
 JS generation loops, and browser font-metric differences that affect layout.
 
-29 out of 128 environments are registered with `nondeterministic=True` in Gymnasium.
+32 out of 128 environments are registered with `nondeterministic=True` in Gymnasium.
 Please [submit a bug report](https://github.com/Farama-Foundation/miniwob-plusplus/issues/new/choose) if you find any new ones.
 ```
 

--- a/docs/content/basic_usage.md
+++ b/docs/content/basic_usage.md
@@ -86,9 +86,11 @@ Not all MiniWoB++ environments are fully deterministic even when seeded.
 Sources of non-determinism include wall-clock-dependent rendering (focus rings, CSS animations),
 jQuery UI widget state that leaks across episode resets, variable `Math.random()` consumption in
 JS generation loops, and browser font-metric differences that affect layout.
+It is highly recommended to pass in `wait_ms=150` or higher when constructing the environment with
+`gymnasium.make` if determinism is desirable as this may allow browser to finish certain tasks.
 
-39 out of 128 environments are registered with `nondeterministic=True` in Gymnasium.
-Please [submit a bug report](https://github.com/Farama-Foundation/miniwob-plusplus/issues/new/choose) if you find any new ones.
+25 out of 128 environments are registered with `nondeterministic=True` in Gymnasium.
+Please report in issue [#119](https://github.com/Farama-Foundation/miniwob-plusplus/issues/119) if you find any new ones.
 ```
 
 The [`reset`](https://gymnasium.farama.org/api/env/#gymnasium.Env.reset)

--- a/miniwob/registration.py
+++ b/miniwob/registration.py
@@ -58,14 +58,17 @@ def register_miniwob_envs():
     register(
         id="miniwob/click-checkboxes-v1",
         entry_point="miniwob.envs.miniwob_envs:ClickCheckboxesEnv",
+        nondeterministic=True,  # focus ring on checkbox captured in screenshot
     )
     register(
         id="miniwob/click-checkboxes-large-v1",
         entry_point="miniwob.envs.miniwob_envs:ClickCheckboxesLargeEnv",
+        nondeterministic=True,  # focus ring on checkbox captured in screenshot
     )
     register(
         id="miniwob/click-checkboxes-soft-v1",
         entry_point="miniwob.envs.miniwob_envs:ClickCheckboxesSoftEnv",
+        nondeterministic=True,  # focus ring on checkbox captured in screenshot
     )
     register(
         id="miniwob/click-checkboxes-transfer-v1",
@@ -187,6 +190,7 @@ def register_miniwob_envs():
     register(
         id="miniwob/copy-paste-2-v1",
         entry_point="miniwob.envs.miniwob_envs:CopyPaste2Env",
+        nondeterministic=True,  # focus ring on textarea/input captured in screenshot
     )
     register(
         id="miniwob/count-shape-v1",
@@ -341,6 +345,7 @@ def register_miniwob_envs():
     register(
         id="miniwob/multi-orderings-v1",
         entry_point="miniwob.envs.miniwob_envs:MultiOrderingsEnv",
+        nondeterministic=True,  # focus ring on form element captured in screenshot
     )
     register(
         id="miniwob/navigate-tree-v1",

--- a/miniwob/registration.py
+++ b/miniwob/registration.py
@@ -442,10 +442,12 @@ def register_miniwob_envs():
     register(
         id="miniwob/use-colorwheel-v1",
         entry_point="miniwob.envs.miniwob_envs:UseColorwheelEnv",
+        nondeterministic=True,  # jscolor popup + focus ring on input captured in screenshot
     )
     register(
         id="miniwob/use-colorwheel-2-v1",
         entry_point="miniwob.envs.miniwob_envs:UseColorwheel2Env",
+        nondeterministic=True,  # jscolor popup + focus ring on input captured in screenshot
     )
     register(
         id="miniwob/use-slider-v1",

--- a/miniwob/registration.py
+++ b/miniwob/registration.py
@@ -462,14 +462,17 @@ def register_miniwob_envs():
     register(
         id="miniwob/flight.Alaska-v1",
         entry_point="miniwob.envs.flightwob_envs:FlightAlaskaEnv",
+        nondeterministic=True,  # iframe loads full airline site; observation depends on async page load timing
     )
     register(
         id="miniwob/flight.Alaska-auto-v1",
         entry_point="miniwob.envs.flightwob_envs:FlightAlaskaAutoEnv",
+        nondeterministic=True,  # iframe loads full airline site; observation depends on async page load timing
     )
     register(
         id="miniwob/flight.AA-v1",
         entry_point="miniwob.envs.flightwob_envs:FlightAAEnv",
+        nondeterministic=True,  # iframe loads full airline site; observation depends on async page load timing
     )
     # MiniWoB test set
     register(

--- a/miniwob/registration.py
+++ b/miniwob/registration.py
@@ -49,7 +49,6 @@ def register_miniwob_envs():
     register(
         id="miniwob/click-button-v1",
         entry_point="miniwob.envs.miniwob_envs:ClickButtonEnv",
-        nondeterministic=True,  # focus ring on form element captured in screenshot
     )
     register(
         id="miniwob/click-button-sequence-v1",
@@ -58,27 +57,22 @@ def register_miniwob_envs():
     register(
         id="miniwob/click-checkboxes-v1",
         entry_point="miniwob.envs.miniwob_envs:ClickCheckboxesEnv",
-        nondeterministic=True,  # focus ring on checkbox captured in screenshot
     )
     register(
         id="miniwob/click-checkboxes-large-v1",
         entry_point="miniwob.envs.miniwob_envs:ClickCheckboxesLargeEnv",
-        nondeterministic=True,  # focus ring on checkbox captured in screenshot
     )
     register(
         id="miniwob/click-checkboxes-soft-v1",
         entry_point="miniwob.envs.miniwob_envs:ClickCheckboxesSoftEnv",
-        nondeterministic=True,  # focus ring on checkbox captured in screenshot
     )
     register(
         id="miniwob/click-checkboxes-transfer-v1",
         entry_point="miniwob.envs.miniwob_envs:ClickCheckboxesTransferEnv",
-        nondeterministic=True,  # focus ring on form element captured in screenshot
     )
     register(
         id="miniwob/click-collapsible-v1",
         entry_point="miniwob.envs.miniwob_envs:ClickCollapsibleEnv",
-        nondeterministic=True,  # accordion animation race with focus() on submit button
     )
     register(
         id="miniwob/click-collapsible-2-v1",
@@ -180,17 +174,14 @@ def register_miniwob_envs():
     register(
         id="miniwob/click-widget-v1",
         entry_point="miniwob.envs.miniwob_envs:ClickWidgetEnv",
-        nondeterministic=True,  # focus ring on form element captured in screenshot
     )
     register(
         id="miniwob/copy-paste-v1",
         entry_point="miniwob.envs.miniwob_envs:CopyPasteEnv",
-        nondeterministic=True,  # focus ring on form element captured in screenshot
     )
     register(
         id="miniwob/copy-paste-2-v1",
         entry_point="miniwob.envs.miniwob_envs:CopyPaste2Env",
-        nondeterministic=True,  # focus ring on textarea/input captured in screenshot
     )
     register(
         id="miniwob/count-shape-v1",
@@ -340,12 +331,10 @@ def register_miniwob_envs():
     register(
         id="miniwob/multi-layouts-v1",
         entry_point="miniwob.envs.miniwob_envs:MultiLayoutsEnv",
-        nondeterministic=True,  # focus ring on form element captured in screenshot
     )
     register(
         id="miniwob/multi-orderings-v1",
         entry_point="miniwob.envs.miniwob_envs:MultiOrderingsEnv",
-        nondeterministic=True,  # focus ring on form element captured in screenshot
     )
     register(
         id="miniwob/navigate-tree-v1",
@@ -366,7 +355,6 @@ def register_miniwob_envs():
     register(
         id="miniwob/resize-textarea-v1",
         entry_point="miniwob.envs.miniwob_envs:ResizeTextareaEnv",
-        nondeterministic=True,  # focus ring on form element captured in screenshot
     )
     register(
         id="miniwob/right-angle-v1",
@@ -442,12 +430,10 @@ def register_miniwob_envs():
     register(
         id="miniwob/use-colorwheel-v1",
         entry_point="miniwob.envs.miniwob_envs:UseColorwheelEnv",
-        nondeterministic=True,  # jscolor popup + focus ring on input captured in screenshot
     )
     register(
         id="miniwob/use-colorwheel-2-v1",
         entry_point="miniwob.envs.miniwob_envs:UseColorwheel2Env",
-        nondeterministic=True,  # jscolor popup + focus ring on input captured in screenshot
     )
     register(
         id="miniwob/use-slider-v1",

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -4,7 +4,11 @@ import pytest
 from gymnasium import spaces
 from gymnasium.utils.env_checker import check_env
 from gymnasium.wrappers import FlattenObservation
-from selenium.common.exceptions import MoveTargetOutOfBoundsException
+from selenium.common.exceptions import (
+    InvalidSessionIdException,
+    JavascriptException,
+    MoveTargetOutOfBoundsException,
+)
 
 from tests.utils import StripNondeterministicInfo, get_all_registered_miniwob_envs
 
@@ -24,12 +28,16 @@ class TestGymAPI:
         # Run check_env to check space containment, determinism, etc.
         for i in range(1, 4):
             try:
-                # We use wrapper to strip key "elapsed" & normalize DOM obs which broke determinism checks.
+                # We use wrapper to normalize DOM & screenshot obs, avoiding benign sources of nondeterminism.
                 check_env(
                     StripNondeterministicInfo(env.unwrapped), skip_render_check=True
                 )
                 break
-            except MoveTargetOutOfBoundsException as e:
+            except (
+                JavascriptException,
+                InvalidSessionIdException,
+                MoveTargetOutOfBoundsException,
+            ) as e:
                 # For random movements, this is kind of inevitable, so we give three chances.
                 print(f"\033[31m{env.unwrapped.spec.id} attempt {i} failed:\033[0m {e}")
         # Check the spaces and flattened spaces.

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -8,9 +8,26 @@ from selenium.common.exceptions import (
     InvalidSessionIdException,
     JavascriptException,
     MoveTargetOutOfBoundsException,
+    SessionNotCreatedException,
 )
+from urllib3.exceptions import ReadTimeoutError
+from urllib3.exceptions import TimeoutError as TimeoutError_urllib3
 
+from miniwob.environment import MiniWoBEnvironment
 from tests.utils import StripNondeterministicInfo, get_all_registered_miniwob_envs
+
+
+RETRY_EXCEPTION = (
+    # Inevitable with random movement
+    MoveTargetOutOfBoundsException,
+    # Some environment have bugs
+    JavascriptException,
+    InvalidSessionIdException,
+    # Selenium / browser issue
+    SessionNotCreatedException,
+    ReadTimeoutError,
+    TimeoutError_urllib3,
+)
 
 
 class TestGymAPI:
@@ -19,7 +36,16 @@ class TestGymAPI:
     @pytest.fixture(params=get_all_registered_miniwob_envs())
     def env(self, request):
         """Yield an environment for the task."""
-        env = gymnasium.make(request.param)
+        env = None
+        for i in range(1, 4):
+            try:
+                env = gymnasium.make(
+                    request.param, wait_ms=150
+                )  # allow browser to finish certain works
+                break
+            except RETRY_EXCEPTION as e:
+                print(f"\033[31mMake {request.param} attempt {i} failed:\033[0m {e}")
+        assert env
         yield env
         env.close()
 
@@ -33,13 +59,16 @@ class TestGymAPI:
                     StripNondeterministicInfo(env.unwrapped), skip_render_check=True
                 )
                 break
-            except (
-                JavascriptException,
-                InvalidSessionIdException,
-                MoveTargetOutOfBoundsException,
-            ) as e:
-                # For random movements, this is kind of inevitable, so we give three chances.
+            except RETRY_EXCEPTION as e:
                 print(f"\033[31m{env.unwrapped.spec.id} attempt {i} failed:\033[0m {e}")
+            except AssertionError:
+                # Increment wait_ms, attempt to save determinism
+                unwrapped_env: MiniWoBEnvironment = env.unwrapped
+                unwrapped_env.instance_kwargs["wait_ms"] += 100.0
+                unwrapped_env.instance.wait_ms += 100.0
+                print(
+                    f"\033[31m{getattr(unwrapped_env.spec, 'id')} wait_ms + 100\033[0m"
+                )
         # Check the spaces and flattened spaces.
         assert isinstance(env.observation_space, spaces.Dict)
         assert set(env.observation_space) == {


### PR DESCRIPTION
# Description

Some async page loading issues are going on with FlightWoB environments. Additionally, `wait_ms=150` is used to mitigate nondeterminism with focus rings.

Continuation of #116 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
