### PR TITLE
Use pytest-xdist to parallelize CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,4 +18,4 @@ jobs:
              --build-arg PYTHON_VERSION=${{ matrix.python-version }} \
              --tag miniwob-plusplus-docker .
       - name: Run tests
-        run: docker run --shm-size=256m miniwob-plusplus-docker pytest -v --timeout=20
+        run: docker run --shm-size=256m miniwob-plusplus-docker pytest -n logical -v --timeout=20

--- a/py.Dockerfile
+++ b/py.Dockerfile
@@ -10,4 +10,4 @@ RUN apt-get install -y chromium chromium-driver
 
 COPY . /usr/local/miniwob-plusplus/
 WORKDIR /usr/local/miniwob-plusplus/
-RUN pip install -e .[testing] --no-cache-dir
+RUN pip install -e .[testing] pytest-xdist --no-cache-dir


### PR DESCRIPTION
# Description

Roughly 2x the speed.

Related PR in other Farama projects:
- https://github.com/Farama-Foundation/ViZDoom/pull/668

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
