### PR TITLE
fix: return non-positive reward for wrong find-greatest submission

### DIFF
--- a/miniwob/envs/miniwob_envs.py
+++ b/miniwob/envs/miniwob_envs.py
@@ -1726,10 +1726,6 @@ class FindGreatestEnv(MiniWoBEnvironment):
     ## Utterance fields
 
     (none)
-
-    ## Additional notes
-
-    * **Partial reward:** If a card is open but it is not the greatest number, the partial reward is 0.1.
     """
 
     subdomain = "find-greatest"

--- a/miniwob/html/miniwob/find-greatest.html
+++ b/miniwob/html/miniwob/find-greatest.html
@@ -76,7 +76,7 @@ var genProblem = function() {
     if(d3.selectAll('.card.hidden')[0].length === 3) {core.endEpisode(-1.0, false); return;}
     var userIndex = d3.select('.card:not(.hidden)')[0][0].getAttribute('data-index');
     if(userIndex === expectedIndex.toString()) core.endEpisode(1.0, true);
-    else core.endEpisode(0.1, true);
+    else core.endEpisode(-1.0, false);
   });
 }
 

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -243,6 +243,102 @@ class TestMiniWoBMode(MiniWoBTester):
 ################################################
 
 
+class TestFindGreatest(MiniWoBTester):
+    """Tests for the find-greatest task (regression for issue #108).
+
+    The task asks the agent to reveal the card with the greatest number and
+    submit. Only one card can be revealed at a time, so the agent must reveal
+    each card in turn to learn its value before submitting the greatest one.
+    """
+
+    ENV_NAME = "miniwob/find-greatest-v1"
+
+    def _card_divs(self, obs):
+        """Return the card <div>s as (left, top) tuples, ordered left-to-right.
+
+        The card divs have a fixed size and are always present in the
+        observation, even while hidden; the numbers themselves only appear
+        once a card is revealed.
+        """
+        cards = [
+            (element["left"].item(), element["top"].item())
+            for element in obs["dom_elements"]
+            if "card" in element["classes"].split()
+        ]
+        return sorted(cards)
+
+    def _create_click_card(self, env, card):
+        """Create an action that clicks on the given card."""
+        left, top = card
+        return env.unwrapped.create_action(
+            ActionTypes.CLICK_COORDS,
+            coords=np.array([left + 5, top + 5], dtype=np.float32),
+        )
+
+    def _revealed_value(self, obs):
+        """Return the number shown on the single currently-revealed card."""
+        for element in obs["dom_elements"]:
+            text = element["text"].strip()
+            if text.isdigit():
+                return int(text)
+        assert False, "no revealed card value found"
+
+    def _reveal_all_values(self, env, obs):
+        """Reveal each card once and return a {card: value} mapping."""
+        values = {}
+        for card in self._card_divs(obs):
+            action = self._create_click_card(env, card)
+            obs, reward, terminated, truncated, info = env.step(action)
+            assert terminated is False
+            values[card] = self._revealed_value(obs)
+        return obs, values
+
+    def test_wrong_card_gives_negative_reward(self, env):
+        """Submitting a non-greatest card must not yield a positive reward.
+
+        Regression for issue #108: the wrong-card branch previously called
+        ``core.endEpisode(0.1, true)``, so an incorrect submission produced a
+        positive terminal reward. Downstream wrappers that treat any positive
+        raw reward as success (e.g. BrowserGym) then counted a wrong answer as
+        a successful run.
+        """
+        obs, info = env.reset()
+        assert len(self._card_divs(obs)) == 3
+        obs, values = self._reveal_all_values(env, obs)
+
+        greatest_card = max(values, key=lambda card: values[card])
+        wrong_card = next(card for card in values if card != greatest_card)
+
+        action = self._create_click_card(env, wrong_card)
+        obs, reward, terminated, truncated, info = env.step(action)
+        assert terminated is False
+        action = self.create_click_button_action(env, obs, "Submit")
+        obs, reward, terminated, truncated, info = env.step(action)
+
+        assert terminated is True
+        assert reward < 0
+
+    def test_greatest_card_gives_positive_reward(self, env):
+        """Submitting the greatest card still yields a positive reward."""
+        obs, info = env.reset()
+        assert len(self._card_divs(obs)) == 3
+        obs, values = self._reveal_all_values(env, obs)
+
+        greatest_card = max(values, key=lambda card: values[card])
+
+        action = self._create_click_card(env, greatest_card)
+        obs, reward, terminated, truncated, info = env.step(action)
+        assert terminated is False
+        action = self.create_click_button_action(env, obs, "Submit")
+        obs, reward, terminated, truncated, info = env.step(action)
+
+        assert terminated is True
+        assert reward > 0
+
+
+################################################
+
+
 class TestMiniWoBFields(MiniWoBTester):
     """Tests for field extraction."""
 


### PR DESCRIPTION
# Description

The `find-greatest` task asks the agent to reveal cards, find the one with the greatest number, and submit it. The wrong-card submission branch in `miniwob/html/miniwob/find-greatest.html` called `core.endEpisode(0.1, true)` — a **positive** terminal reward for an incorrect answer. Since `endEpisode`'s second argument is `time_proportional` (not a success flag), there is no separate success channel, and downstream wrappers that treat any positive raw reward as success (e.g. BrowserGym's `float(RAW_REWARD_GLOBAL > 0)`) count a wrong submission as a successful run.

This PR changes the wrong-card branch to `core.endEpisode(-1.0, false)`, matching:

- the repo-wide convention for incorrect submissions (e.g. `bisect-angle.html`, and the idiom `endEpisode(r, r > 0)` used elsewhere),
- the task's own no-card-selected branch on the line directly above, and
- the documented binary reward model (`get_binary_reward`, terminal reward of −1 or 1).

It also removes the now-stale "Partial reward: 0.1" note from the `FindGreatestEnv` docstring (binary-outcome envs in `miniwob_envs.py` omit that section), and adds regression tests in `tests/test_environment.py` (`TestFindGreatest`): one that reveals each card, submits a non-greatest card, and asserts the terminal reward is negative (verified to fail against the pre-fix HTML), plus a happy-path guard asserting the greatest card still yields a positive reward.

No new dependencies.

Fixes #108

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Screenshots

N/A — no visual change; this only alters the terminal reward returned for an incorrect submission.

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
